### PR TITLE
Composite event context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ Backup*/
 UpgradeLog*.XML
 project.lock.json
 .vs/
+
+# VSCode support files
+.vscode/

--- a/src/Spiffy.Monitoring.NLog/NLog.cs
+++ b/src/Spiffy.Monitoring.NLog/NLog.cs
@@ -26,7 +26,7 @@ namespace Spiffy.Monitoring
 
             _logger = SetupNLog(config);
 
-            LoggingFacade.Initialize((level, message) =>
+            LoggingFacade.Instance.Initialize((level, message) =>
             {
                 var nLogLevel = LevelToNLogLevel(level);
                 _logger.Log(nLogLevel, message);

--- a/src/Spiffy.Monitoring.NLog/NLog.cs
+++ b/src/Spiffy.Monitoring.NLog/NLog.cs
@@ -8,28 +8,6 @@ using NLog.Targets.Wrappers;
 
 namespace Spiffy.Monitoring
 {
-    public static class NLogFactory
-    {
-        public static ILoggingFacade Create(Action<NLogConfigurationApi> configure = null, string name = null) 
-        {
-            var config = new NLogConfigurationApi();
-            if(null != configure)
-            {
-                configure(config);
-            }
-
-            var logger = NLog.SetupNLog(config, name);
-
-            var loggingFacade = LoggingFacadeFactory.Create((level, message) =>
-            {
-                var nLogLevel = NLog.LevelToNLogLevel(level);
-                logger.Log(nLogLevel, message);
-            });
-
-            return loggingFacade;
-        }
-
-    }
     public static class NLog
     {
         private const string LoggerName = "Spiffy";

--- a/src/Spiffy.Monitoring.NLog/NLogFactory.cs
+++ b/src/Spiffy.Monitoring.NLog/NLogFactory.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Spiffy.Monitoring
+{
+    public static class NLogFactory
+    {
+        /// <summary>
+        /// Creates an instance of an NLog enabled LoggingFacade
+        /// </summary>
+        /// <remarks>
+        /// If using more than one NLog facade in an application, remember to give them unique names
+        /// </remarks>
+        public static ILoggingFacade Create(Action<NLogConfigurationApi> configure = null, string name = null) 
+        {
+            var config = new NLogConfigurationApi();
+            if(null != configure)
+            {
+                configure(config);
+            }
+
+            var logger = NLog.SetupNLog(config, name);
+
+            var loggingFacade = LoggingFacadeFactory.Create((level, message) =>
+            {
+                var nLogLevel = NLog.LevelToNLogLevel(level);
+                logger.Log(nLogLevel, message);
+            });
+            
+            return loggingFacade;
+        }
+    }
+}

--- a/src/Spiffy.Monitoring/CompositeEventContext.cs
+++ b/src/Spiffy.Monitoring/CompositeEventContext.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Spiffy.Monitoring
+{
+    public class CompositeEventContext : EventContext
+    {
+        public CompositeEventContext(string component, string operation, IDictionary<string, ILoggingFacade> loggerCollection) : base(component, operation)
+        {
+            if(null == loggerCollection)
+                throw new ArgumentNullException(nameof(loggerCollection));
+
+            LoggerCollection = loggerCollection;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public CompositeEventContext() : base(null, null)
+        {
+            LoggerCollection.Add("default", LoggingFacade.Instance);
+        }
+
+        public IDictionary<string, ILoggingFacade> LoggerCollection { get; protected set; } = new Dictionary<string, ILoggingFacade>();
+
+        protected override void Dispose(bool disposing) {
+            if( !_disposed)
+            {
+                this["TimeElapsed"] = GetTimeFor(_timer.TotalMilliseconds);
+                foreach(var logger in LoggerCollection) {
+                    logger.Value.Log(Level, GetFormattedMessage());
+                }
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/src/Spiffy.Monitoring/CompositeEventContext.cs
+++ b/src/Spiffy.Monitoring/CompositeEventContext.cs
@@ -12,26 +12,44 @@ namespace Spiffy.Monitoring
         public CompositeEventContext(string component, string operation, IDictionary<string, ILoggingFacade> loggerCollection) : base(component, operation)
         {
             if(null == loggerCollection)
-                throw new ArgumentNullException(nameof(loggerCollection));
-
-            LoggerCollection = loggerCollection;
+            {
+                LoggerCollection.Add("default", DefaultLoggingFacade.Instance);
+            }
+            else
+            {
+                LoggerCollection = new Dictionary<string, ILoggingFacade>(loggerCollection);
+            }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public CompositeEventContext() : base()
+        public CompositeEventContext(IDictionary<string, ILoggingFacade> loggerCollection = null) : base()
         {
-            LoggerCollection.Add("default", DefaultLoggingFacade.Instance);
+            if(null == loggerCollection)
+            {
+                LoggerCollection.Add("default", DefaultLoggingFacade.Instance);
+            }
+            else
+            {
+                LoggerCollection = new Dictionary<string, ILoggingFacade>(loggerCollection);
+            }
         }
 
         public IDictionary<string, ILoggingFacade> LoggerCollection { get; protected set; } = new Dictionary<string, ILoggingFacade>();
 
-        protected override void Dispose(bool disposing) {
+        protected override void Dispose(bool disposing)
+        {
             if( !_disposed)
             {
                 this["TimeElapsed"] = GetTimeFor(_timer.TotalMilliseconds);
                 foreach(var logger in LoggerCollection) {
                     logger.Value.Log(Level, GetFormattedMessage(logger.Key));
                 }
+
+                if(disposing)
+                {
+                    LoggerCollection = null;
+                }
+
                 _disposed = true;
             }
         }

--- a/src/Spiffy.Monitoring/CompositeEventContext.cs
+++ b/src/Spiffy.Monitoring/CompositeEventContext.cs
@@ -20,7 +20,7 @@ namespace Spiffy.Monitoring
         [MethodImpl(MethodImplOptions.NoInlining)]
         public CompositeEventContext() : base()
         {
-            LoggerCollection.Add("default", LoggingFacade.Instance);
+            LoggerCollection.Add("default", DefaultLoggingFacade.Instance);
         }
 
         public IDictionary<string, ILoggingFacade> LoggerCollection { get; protected set; } = new Dictionary<string, ILoggingFacade>();

--- a/src/Spiffy.Monitoring/CompositeEventContext.cs
+++ b/src/Spiffy.Monitoring/CompositeEventContext.cs
@@ -18,7 +18,7 @@ namespace Spiffy.Monitoring
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public CompositeEventContext() : base(null, null)
+        public CompositeEventContext() : base()
         {
             LoggerCollection.Add("default", LoggingFacade.Instance);
         }
@@ -30,7 +30,7 @@ namespace Spiffy.Monitoring
             {
                 this["TimeElapsed"] = GetTimeFor(_timer.TotalMilliseconds);
                 foreach(var logger in LoggerCollection) {
-                    logger.Value.Log(Level, GetFormattedMessage());
+                    logger.Value.Log(Level, GetFormattedMessage(logger.Key));
                 }
                 _disposed = true;
             }

--- a/src/Spiffy.Monitoring/DefaultLoggingFacade.cs
+++ b/src/Spiffy.Monitoring/DefaultLoggingFacade.cs
@@ -1,0 +1,15 @@
+namespace Spiffy.Monitoring
+{
+    public class DefaultLoggingFacade: LoggingFacade
+    {
+        private DefaultLoggingFacade()
+        {}
+
+        static ILoggingFacade _instance;
+
+        public static ILoggingFacade Instance
+        {
+            get { return _instance ?? (_instance = LoggingFacadeFactory.Create()); }
+        }
+    }
+}

--- a/src/Spiffy.Monitoring/EventContext.cs
+++ b/src/Spiffy.Monitoring/EventContext.cs
@@ -174,7 +174,7 @@ namespace Spiffy.Monitoring
             {
                 // Base class has nothing special to dispose, so disposing value is not used
                 this["TimeElapsed"] = GetTimeFor(_timer.TotalMilliseconds);
-                LoggingFacade.Instance.Log(Level, GetFormattedMessage());
+                DefaultLoggingFacade.Instance.Log(Level, GetFormattedMessage());
                 _disposed = true;
             }
         }

--- a/src/Spiffy.Monitoring/ILoggingFacade.cs
+++ b/src/Spiffy.Monitoring/ILoggingFacade.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Spiffy.Monitoring
+{
+    public interface ILoggingFacade
+    {
+        void Log(Level level, string message);
+        void Initialize(Action<Level, string> logAction);
+        void Initialize(LoggingBehavior behavior);
+    }
+}

--- a/src/Spiffy.Monitoring/LoggingFacade.cs
+++ b/src/Spiffy.Monitoring/LoggingFacade.cs
@@ -7,22 +7,34 @@ namespace Spiffy.Monitoring
         void Log(Level level, string message);
         void Initialize(Action<Level, string> logAction);
         void Initialize(LoggingBehavior behavior);
-
     }
 
-    public class LoggingFacade: ILoggingFacade
-    {
-        private LoggingFacade()
-        {}
-
-        static ILoggingFacade _instance;
-
-        public static ILoggingFacade Instance
+    public static class LoggingFacadeFactory {
+        public static ILoggingFacade Create(Action<Level, string> logAction)
         {
-            get { return _instance ?? (_instance = new LoggingFacade()); }
+            var loggingFacade = new LoggingFacade();
+            loggingFacade.Initialize(logAction);
+            return loggingFacade;
         }
 
-        private Action<Level, string> _logAction;
+        public static ILoggingFacade Create(LoggingBehavior behavior)
+        {
+            var loggingFacade = new LoggingFacade();
+            loggingFacade.Initialize(behavior);
+            return loggingFacade;
+        }
+
+        public static ILoggingFacade Create()
+        {
+            var loggingFacade = new LoggingFacade();
+            loggingFacade.Initialize();
+            return loggingFacade;
+        }
+    }
+
+    public class LoggingFacade : ILoggingFacade
+    {
+        protected Action<Level, string> _logAction;
 
         public virtual void Initialize(Action<Level, string> logAction)
         {
@@ -51,6 +63,19 @@ namespace Spiffy.Monitoring
                 Initialize();
             }
             _logAction(level, message);
+        }
+    }
+
+    public class DefaultLoggingFacade: LoggingFacade
+    {
+        private DefaultLoggingFacade()
+        {}
+
+        static ILoggingFacade _instance;
+
+        public static ILoggingFacade Instance
+        {
+            get { return _instance ?? (_instance = LoggingFacadeFactory.Create()); }
         }
     }
 

--- a/src/Spiffy.Monitoring/LoggingFacade.cs
+++ b/src/Spiffy.Monitoring/LoggingFacade.cs
@@ -13,8 +13,7 @@ namespace Spiffy.Monitoring
     public class LoggingFacade: ILoggingFacade
     {
         private LoggingFacade()
-        {
-        }
+        {}
 
         static ILoggingFacade _instance;
 

--- a/src/Spiffy.Monitoring/LoggingFacade.cs
+++ b/src/Spiffy.Monitoring/LoggingFacade.cs
@@ -3,35 +3,6 @@ using System.Diagnostics;
 
 namespace Spiffy.Monitoring
 {
-    public interface ILoggingFacade {
-        void Log(Level level, string message);
-        void Initialize(Action<Level, string> logAction);
-        void Initialize(LoggingBehavior behavior);
-    }
-
-    public static class LoggingFacadeFactory {
-        public static ILoggingFacade Create(Action<Level, string> logAction)
-        {
-            var loggingFacade = new LoggingFacade();
-            loggingFacade.Initialize(logAction);
-            return loggingFacade;
-        }
-
-        public static ILoggingFacade Create(LoggingBehavior behavior)
-        {
-            var loggingFacade = new LoggingFacade();
-            loggingFacade.Initialize(behavior);
-            return loggingFacade;
-        }
-
-        public static ILoggingFacade Create()
-        {
-            var loggingFacade = new LoggingFacade();
-            loggingFacade.Initialize();
-            return loggingFacade;
-        }
-    }
-
     public class LoggingFacade : ILoggingFacade
     {
         protected Action<Level, string> _logAction;
@@ -63,19 +34,6 @@ namespace Spiffy.Monitoring
                 Initialize();
             }
             _logAction(level, message);
-        }
-    }
-
-    public class DefaultLoggingFacade: LoggingFacade
-    {
-        private DefaultLoggingFacade()
-        {}
-
-        static ILoggingFacade _instance;
-
-        public static ILoggingFacade Instance
-        {
-            get { return _instance ?? (_instance = LoggingFacadeFactory.Create()); }
         }
     }
 

--- a/src/Spiffy.Monitoring/LoggingFacade.cs
+++ b/src/Spiffy.Monitoring/LoggingFacade.cs
@@ -3,16 +3,34 @@ using System.Diagnostics;
 
 namespace Spiffy.Monitoring
 {
-    public static class LoggingFacade
-    {
-        private static Action<Level, string> _logAction;
+    public interface ILoggingFacade {
+        void Log(Level level, string message);
+        void Initialize(Action<Level, string> logAction);
+        void Initialize(LoggingBehavior behavior);
 
-        public static void Initialize(Action<Level, string> logAction)
+    }
+
+    public class LoggingFacade: ILoggingFacade
+    {
+        private LoggingFacade()
+        {
+        }
+
+        static ILoggingFacade _instance;
+
+        public static ILoggingFacade Instance
+        {
+            get { return _instance ?? (_instance = new LoggingFacade()); }
+        }
+
+        private Action<Level, string> _logAction;
+
+        public virtual void Initialize(Action<Level, string> logAction)
         {
             _logAction = logAction;
         }
 
-        public static void Initialize(LoggingBehavior behavior = LoggingBehavior.Console)
+        public virtual void Initialize(LoggingBehavior behavior = LoggingBehavior.Console)
         {
             switch (behavior)
             {
@@ -27,7 +45,7 @@ namespace Spiffy.Monitoring
             }
         }
 
-        public static void Log(Level level, string message)
+        public void Log(Level level, string message)
         {
             if (_logAction == null)
             {

--- a/src/Spiffy.Monitoring/LoggingFacadeFactory.cs
+++ b/src/Spiffy.Monitoring/LoggingFacadeFactory.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Spiffy.Monitoring
+{
+    public static class LoggingFacadeFactory 
+    {
+        public static ILoggingFacade Create(Action<Level, string> logAction)
+        {
+            var loggingFacade = new LoggingFacade();
+            loggingFacade.Initialize(logAction);
+            return loggingFacade;
+        }
+
+        public static ILoggingFacade Create(LoggingBehavior behavior)
+        {
+            var loggingFacade = new LoggingFacade();
+            loggingFacade.Initialize(behavior);
+            return loggingFacade;
+        }
+
+        public static ILoggingFacade Create()
+        {
+            var loggingFacade = new LoggingFacade();
+            loggingFacade.Initialize();
+            return loggingFacade;
+        }
+    }
+}

--- a/tests/TestConsoleApp/Program.cs
+++ b/tests/TestConsoleApp/Program.cs
@@ -21,10 +21,10 @@ namespace TestConsoleApp
                             .LogToPath(@"Logs"));
                     break;
                     case "trace":
-                        LoggingFacade.Initialize(LoggingBehavior.Trace);
+                        LoggingFacade.Instance.Initialize(LoggingBehavior.Trace);
                     break;
                     case "console":
-                        LoggingFacade.Initialize(LoggingBehavior.Console);
+                        LoggingFacade.Instance.Initialize(LoggingBehavior.Console);
                     break;
                 }
             }

--- a/tests/TestConsoleApp/Program.cs
+++ b/tests/TestConsoleApp/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using NLog.Targets;
 using Spiffy.Monitoring;
@@ -7,6 +9,7 @@ namespace TestConsoleApp
 {
     class Program
     {
+        private static Dictionary<string, ILoggingFacade> loggerCollection = new Dictionary<string, ILoggingFacade>();
         static void Main(string [] args)
         {
             if (args?.Length > 0)
@@ -21,10 +24,19 @@ namespace TestConsoleApp
                             .LogToPath(@"Logs"));
                     break;
                     case "trace":
-                        LoggingFacade.Instance.Initialize(LoggingBehavior.Trace);
+                        DefaultLoggingFacade.Instance.Initialize(LoggingBehavior.Trace);
                     break;
                     case "console":
-                        LoggingFacade.Instance.Initialize(LoggingBehavior.Console);
+                        DefaultLoggingFacade.Instance.Initialize(LoggingBehavior.Console);
+                    break;
+                    case "composite":
+                        loggerCollection.Add("console", LoggingFacadeFactory.Create(LoggingBehavior.Console));
+                        loggerCollection.Add("trace", LoggingFacadeFactory.Create(LoggingBehavior.Trace));
+                        loggerCollection.Add("nlog", NLogFactory.Create(c => c
+                            .ArchiveEvery(FileArchivePeriod.Minute)
+                            .KeepMaxArchiveFiles(5)
+                            .MinLogLevel(Level.Info)
+                            .LogToPath(@"Logs")));
                     break;
                 }
             }
@@ -39,6 +51,19 @@ namespace TestConsoleApp
 
             Console.WriteLine("Running application.  Logs are either emitted here, or to 'Logs'");
             
+            if(loggerCollection.Any())
+            {
+                Console.WriteLine("Using CompositeEventContext");
+                CompositeContext();
+            }
+            else
+            {
+                Console.WriteLine("Using Default EventContext");
+                SimpleContext();
+            }
+        }
+
+        static void SimpleContext() {
             // info:
             using (var context = new EventContext("Greetings", "Start"))
             {
@@ -62,6 +87,49 @@ namespace TestConsoleApp
             while (DateTime.UtcNow < cutOffTime)
             {
                 using (var context = new EventContext())
+                {
+                    context["MyCustomValue"] = "foo";
+
+                    using (context.Time("LongRunning"))
+                    {
+                        DoSomethingLongRunning();
+                    }
+
+                    try
+                    {
+                        DoSomethingDangerous();
+                    }
+                    catch (Exception ex)
+                    {
+                        context.IncludeException(ex);
+                    }
+                }
+            }
+        }
+        static void CompositeContext() {
+            // info:
+            using (var context = new CompositeEventContext("Greetings", "Start", loggerCollection))
+            {
+                context["Greeting"] = "Hello world!";
+            }
+
+            // warning:
+            using (var context = new CompositeEventContext(loggerCollection))
+            {
+                context.SetToWarning("cause something sorta bad happened");
+            }
+
+            // error:
+            using (var context = new CompositeEventContext(loggerCollection))
+            {
+                context.SetToError("cause something very bad happened");
+            }
+
+            var cutOffTime = DateTime.UtcNow.AddMinutes(5);
+
+            while (DateTime.UtcNow < cutOffTime)
+            {
+                using (var context = new CompositeEventContext(loggerCollection))
                 {
                     context["MyCustomValue"] = "foo";
 

--- a/tests/UnitTests/CompositeEvents.cs
+++ b/tests/UnitTests/CompositeEvents.cs
@@ -20,7 +20,7 @@ namespace UnitTests
         public void Named_event()
         {
             // When:
-            var context = new CompositeEventContext("MyComponent", "MyOperation", new Dictionary<string, ILoggingFacade> { {"default", LoggingFacade.Instance} });
+            var context = new CompositeEventContext("MyComponent", "MyOperation", new Dictionary<string, ILoggingFacade> { {"default", DefaultLoggingFacade.Instance} });
             // Then:
             Assert.Equal("MyComponent", context.Component);
             Assert.Equal("MyOperation", context.Operation);

--- a/tests/UnitTests/CompositeEvents.cs
+++ b/tests/UnitTests/CompositeEvents.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Spiffy.Monitoring;
+using Xunit;
+
+namespace UnitTests
+{
+    public class CompositeEvents
+    {
+        [Fact]
+        public void Unnamed_event()
+        {
+            // When:
+            var context = new CompositeEventContext();
+            // Then:
+            Assert.Equal(GetType().Name, context.Component);
+            Assert.Equal("Unnamed_event", context.Operation);
+        }
+
+        [Fact]
+        public void Named_event()
+        {
+            // When:
+            var context = new CompositeEventContext("MyComponent", "MyOperation", new Dictionary<string, ILoggingFacade> { {"default", LoggingFacade.Instance} });
+            // Then:
+            Assert.Equal("MyComponent", context.Component);
+            Assert.Equal("MyOperation", context.Operation);
+        }
+    }
+}

--- a/tests/UnitTests/Publishing.cs
+++ b/tests/UnitTests/Publishing.cs
@@ -57,7 +57,7 @@ namespace UnitTests
         {
             public PublishingTestContext()
             {
-                LoggingFacade.Instance.Initialize((level, msg) =>
+                DefaultLoggingFacade.Instance.Initialize((level, msg) =>
                     Messages.Add(new Tuple<Level, string>(level, msg)));
             }
 

--- a/tests/UnitTests/Publishing.cs
+++ b/tests/UnitTests/Publishing.cs
@@ -57,7 +57,7 @@ namespace UnitTests
         {
             public PublishingTestContext()
             {
-                LoggingFacade.Initialize((level, msg) =>
+                LoggingFacade.Instance.Initialize((level, msg) =>
                     Messages.Add(new Tuple<Level, string>(level, msg)));
             }
 


### PR DESCRIPTION
Should be backwards-compatible. 

- Updates `EventContext` to be more friendly to inheritance.
- Adds `CompositeEventContext` which can take a dictionary of `ILoggingFacade` to allow multiple log actions to be taken.
- Adds ability to create multiple NLog facades via Factory, while keeping old behavior
- UnitTests and TestApp updated