### PR TITLE
Create AddValues methods to simplify context population

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ Backup*/
 UpgradeLog*.XML
 project.lock.json
 .vs/
+.vscode/

--- a/src/Spiffy.Monitoring/EventContext.cs
+++ b/src/Spiffy.Monitoring/EventContext.cs
@@ -303,5 +303,27 @@ namespace Spiffy.Monitoring
         {
             return string.Format("{0:F1}", milliseconds);
         }
+
+        public void AddValues (params KeyValuePair<string, string>[] values)
+        {
+            lock (_valuesSyncObject)
+            {
+                foreach (var kvp in values)
+                {
+                    _values[kvp.Key] = kvp.Value;
+                }
+            }
+        }
+
+        public void AddValues(IEnumerable<KeyValuePair<string, string>> values)
+        {
+            lock(_valuesSyncObject)
+            {
+                foreach(var kvp in values)
+                {
+                    _values[kvp.Key] = kvp.Value;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds two AddValues methods. One for params, one for a dictionary (IEnumerable<kvp>)

