### PR TITLE
Added a Suppress method to EventContext

### DIFF
--- a/src/Spiffy.Monitoring/EventContext.cs
+++ b/src/Spiffy.Monitoring/EventContext.cs
@@ -186,13 +186,24 @@ namespace Spiffy.Monitoring
             }
         }
 
+        public bool IsSuppressed { get; private set; }
+
+        public void Suppress()
+        {
+            IsSuppressed = true;
+        }
+
         volatile bool _disposed = false;
+
         public void Dispose()
         {
             if (!_disposed)
             {
-                this["TimeElapsed"] = GetTimeFor(_timer.TotalMilliseconds);
-                LoggingFacade.Log(Level, GetFormattedMessage());
+                if(!IsSuppressed)
+                {
+                    this["TimeElapsed"] = GetTimeFor(_timer.TotalMilliseconds);
+                    LoggingFacade.Log(Level, GetFormattedMessage());
+                }
                 _disposed = true;
             }
         }

--- a/tests/UnitTests/Publishing.cs
+++ b/tests/UnitTests/Publishing.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Collections.Generic;
 using FluentAssertions;
+using Kekiri;
 using Kekiri.TestRunner.xUnit;
 using Spiffy.Monitoring;
 
@@ -18,7 +19,16 @@ namespace UnitTests
             When(Disposing_an_event_context);
             Then(It_should_publish_the_log_message);
         }
-    
+
+        [Scenario]
+        public void Suppressed_events_are_not_published()
+        {
+            Given(A_publishing_context)
+            .And(EventContext_is_suppressed);
+            When(Disposing_an_event_context);
+            Then(It_should_not_publish_the_log_message);
+        }
+
         [Scenario]
         public void Events_are_only_published_once()
         {
@@ -32,6 +42,11 @@ namespace UnitTests
         void A_publishing_context()
         {
             _context =new PublishingTestContext();
+        }
+
+        void EventContext_is_suppressed()
+        {
+            _context.EventContext.Suppress();
         }
 
         void Disposing_an_event_context()
@@ -49,6 +64,11 @@ namespace UnitTests
         void It_should_not_publish_again()
         {
             _context.Messages.Count.Should().Be(1);
+        }
+
+        void It_should_not_publish_the_log_message()
+        {
+            _context.Messages.Count.Should().Be(0);
         }
 
         class PublishingTestContext


### PR DESCRIPTION
 This allows you to prevent an EventContext that has already been created to not log when its disposed.