### PR TITLE
Introduce API for timers

### DIFF
--- a/src/Spiffy.Monitoring/AutoTimer.cs
+++ b/src/Spiffy.Monitoring/AutoTimer.cs
@@ -15,7 +15,6 @@ namespace Spiffy.Monitoring
         }
 
         public double ElapsedMilliseconds => _stopwatch.Elapsed.TotalMilliseconds;
-        public bool IsRunning => _stopwatch.IsRunning;
 
         public void Dispose()
         {
@@ -36,6 +35,10 @@ namespace Spiffy.Monitoring
 
         void Start()
         {
+            if (_stopwatch.IsRunning)
+            {
+                return;
+            }
             Count++;
             _stopwatch.Start();
         }

--- a/src/Spiffy.Monitoring/AutoTimer.cs
+++ b/src/Spiffy.Monitoring/AutoTimer.cs
@@ -15,6 +15,7 @@ namespace Spiffy.Monitoring
         }
 
         public double ElapsedMilliseconds => _stopwatch.Elapsed.TotalMilliseconds;
+        public bool IsRunning => _stopwatch.IsRunning;
 
         public void Dispose()
         {
@@ -23,6 +24,13 @@ namespace Spiffy.Monitoring
 
         public void Resume()
         {
+            Start();
+        }
+
+        public void StartOver()
+        {
+            _stopwatch.Reset();
+            Count = 0;
             Start();
         }
 

--- a/src/Spiffy.Monitoring/Spiffy.Monitoring.csproj
+++ b/src/Spiffy.Monitoring/Spiffy.Monitoring.csproj
@@ -26,7 +26,7 @@ New features:
     <PackageProjectUrl>http://github.com/chris-peterson/spiffy</PackageProjectUrl>
     <PackageLicense>http://opensource.org/licenses/MIT</PackageLicense>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>6.0.5</Version>
+    <Version>6.0.6</Version>
     <RootNamespace>Spiffy.Monitoring</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Spiffy.Monitoring/TimerCollection.cs
+++ b/src/Spiffy.Monitoring/TimerCollection.cs
@@ -9,7 +9,7 @@ namespace Spiffy.Monitoring
     {
         readonly ConcurrentDictionary<string, AutoTimer> _timers = new ConcurrentDictionary<string, AutoTimer>();
         
-        public ITimedContext Replace(string key)
+        public ITimedContext TimeOnce(string key)
         {
             var timer = GetTimer(key);
             timer.StartOver();
@@ -19,10 +19,7 @@ namespace Spiffy.Monitoring
         public ITimedContext Accumulate(string key)
         {
             var timer = GetTimer(key);
-            if (!timer.IsRunning)
-            {
-                timer.Resume();
-            }
+            timer.Resume();
             return timer;
         }
         internal Dictionary<string, AutoTimer> ShallowClone() => new Dictionary<string, AutoTimer>(_timers);

--- a/src/Spiffy.Monitoring/TimerCollection.cs
+++ b/src/Spiffy.Monitoring/TimerCollection.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Spiffy.Monitoring
+{
+    public class TimerCollection
+    {
+        readonly ConcurrentDictionary<string, AutoTimer> _timers = new ConcurrentDictionary<string, AutoTimer>();
+        
+        public ITimedContext Replace(string key)
+        {
+            var timer = GetTimer(key);
+            timer.StartOver();
+            return timer;
+        }
+
+        public ITimedContext Accumulate(string key)
+        {
+            var timer = GetTimer(key);
+            if (!timer.IsRunning)
+            {
+                timer.Resume();
+            }
+            return timer;
+        }
+        internal Dictionary<string, AutoTimer> ShallowClone() => new Dictionary<string, AutoTimer>(_timers);
+
+        AutoTimer GetTimer(string key)
+        {
+            return _timers.GetOrAdd(key, _ => new AutoTimer());
+        }
+    }
+}

--- a/tests/UnitTests/ConcurrencyTests.cs
+++ b/tests/UnitTests/ConcurrencyTests.cs
@@ -27,7 +27,7 @@ namespace UnitTests
             Configuration.Initialize(c => c.Providers.Add(GetType().Name, le => logEvent = le ));
             eventContext.Dispose();
 
-            Assert.InRange(int.Parse(logEvent.Properties["Count_accum"]), numTasks*.65, numTasks*.95);
+            Assert.InRange(int.Parse(logEvent.Properties["Count_accum"]), numTasks*.65, numTasks*.99);
             Assert.DoesNotContain("Count_once", logEvent.Properties);
             Assert.True(double.Parse(logEvent.Properties["TimeElapsed_accum"]) > double.Parse(logEvent.Properties["TimeElapsed_once"]));
         }

--- a/tests/UnitTests/ConcurrencyTests.cs
+++ b/tests/UnitTests/ConcurrencyTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Spiffy.Monitoring;
+using Xunit;
+
+namespace UnitTests
+{
+    public class ConcurrencyTests
+    {
+        [Fact]
+        public void TestTimers()
+        {
+            var eventContext = new EventContext();
+            var tasks = new List<Task>();
+            const int numTasks = 100;
+            for (int i = 0; i < numTasks; i++)
+            {
+                var task = new Task(StaggeredMeasurements, new object [] {i, eventContext});
+                task.Start();
+                tasks.Add(task);
+            }
+
+            Task.WaitAll(tasks.ToArray());
+
+            LogEvent logEvent = null;
+            Configuration.Initialize(c => c.Providers.Add(GetType().Name, le => logEvent = le ));
+            eventContext.Dispose();
+
+            Assert.InRange(int.Parse(logEvent.Properties["Count_accum"]), numTasks*.65, numTasks*.95);
+            Assert.DoesNotContain("Count_once", logEvent.Properties);
+            Assert.True(double.Parse(logEvent.Properties["TimeElapsed_accum"]) > double.Parse(logEvent.Properties["TimeElapsed_once"]));
+        }
+
+        static void StaggeredMeasurements(object state)
+        {
+            var param = (object[]) state;
+            var delay = (int) param[0];
+            var eventContext = (EventContext) param[1];
+            using (eventContext.Timers.Accumulate("accum"))
+            using (eventContext.Timers.TimeOnce("once"))
+            {
+                Thread.Sleep(delay);
+            }
+        }
+    }
+}

--- a/tests/UnitTests/TimerCollectionTests.cs
+++ b/tests/UnitTests/TimerCollectionTests.cs
@@ -27,7 +27,7 @@ namespace UnitTests
 
         void A_code_block_timed_once()
         {
-            using (EventContext.Timers.Replace(TimerKey))
+            using (EventContext.Timers.TimeOnce(TimerKey))
             {
                 Thread.Sleep(10);
             }

--- a/tests/UnitTests/TimerCollectionTests.cs
+++ b/tests/UnitTests/TimerCollectionTests.cs
@@ -1,0 +1,74 @@
+﻿using System.Threading;
+using Spiffy.Monitoring;
+using Kekiri.Xunit;
+using Xunit;
+
+namespace UnitTests
+{
+    public class TimerCollectionTests : Scenarios
+    {
+        [Scenario]
+        public void TimeOnceScenario()
+        {
+            Given(A_code_block_timed_once);
+            When(Event_is_logged);
+            Then(The_time_elapsed_field_should_be_near, 10)
+                .And(There_should_be_no_count_field);
+        }
+
+        [Scenario]
+        public void AccumulateScenario()
+        {
+            Given(A_code_block_timed_multiple_times);
+            When(Event_is_logged);
+            Then(The_time_elapsed_field_should_be_near, 20)
+                .And(There_should_be_a_count_field);
+        }
+
+        void A_code_block_timed_once()
+        {
+            using (EventContext.Timers.Replace(TimerKey))
+            {
+                Thread.Sleep(10);
+            }
+        }
+
+        void A_code_block_timed_multiple_times()
+        {
+            for (int i = 0; i < 2; i++)
+            {
+                using (EventContext.Timers.Accumulate(TimerKey))
+                {
+                    Thread.Sleep(10);
+                }
+            }
+        }
+        
+        void Event_is_logged()
+        {
+            Configuration.Initialize(c => c.Providers.Add(GetType().Name, logEvent => LoggedEvent = logEvent));
+            EventContext.Dispose();
+        }
+
+        void The_time_elapsed_field_should_be_near(int target)
+        {
+            Assert.InRange(double.Parse(LoggedEvent.Properties[$"TimeElapsed_{TimerKey}"]), target-5, target+5);
+        }
+
+        void There_should_be_no_count_field()
+        {
+            Assert.DoesNotContain($"Count_{TimerKey}", LoggedEvent.Properties);
+        }
+
+        void There_should_be_a_count_field()
+        {
+            var keyName = $"Count_{TimerKey}";
+            Assert.Contains(keyName, LoggedEvent.Properties);
+            Assert.Equal(2, int.Parse(LoggedEvent.Properties[keyName]));
+        }
+
+        EventContext EventContext { get; } = new EventContext();
+        LogEvent LoggedEvent { get; set; }
+        const string TimerKey = "abc";
+    }
+}


### PR DESCRIPTION
This gives the client control over the behavior of multiple invocations (replace/accumulate)
The timer API returns the new `ITimedContext` interface, something that couldn't be done with
the existing `Time` method without breaking a lot of existing codebases (the yanked 6.0.4 version)