### PR TITLE
Order by value length

### DIFF
--- a/src/Spiffy.Monitoring/EventContext.cs
+++ b/src/Spiffy.Monitoring/EventContext.cs
@@ -331,7 +331,9 @@ namespace Spiffy.Monitoring
 
         private static string GetKeyValuePairsAsDelimitedString(Dictionary<string, string> keyValuePairs)
         {
-            return string.Join(" ", keyValuePairs.Select(kvp =>
+            return string.Join(" ", keyValuePairs
+                .OrderBy(pair => pair.Value.Length)
+                .Select(kvp =>
                 string.Format("{0}={1}", kvp.Key, kvp.Value)).ToArray());
         }
 


### PR DESCRIPTION
In a situation where a log is overlong and the underlying
log capture "system" is forced to cut off the log, this
maximizes the count of KV pairs that are included in the
log message.