### PR TITLE
Work with a broader set of underlying frameworks

### DIFF
--- a/src/Spiffy.Monitoring.Prometheus/PrometheusConfigurationApi.cs
+++ b/src/Spiffy.Monitoring.Prometheus/PrometheusConfigurationApi.cs
@@ -1,14 +1,14 @@
-using Prometheus.DotNetRuntime;
-
 namespace Spiffy.Monitoring.Prometheus
 {
     public class PrometheusConfigurationApi
     {
+#if NET6_0_OR_GREATER
         public PrometheusConfigurationApi()
         {
-            RuntimeStats = DotNetRuntimeStatsBuilder.Customize();
+            RuntimeStats = global::Prometheus.DotNetRuntime.DotNetRuntimeStatsBuilder.Customize();
         }
 
-        public DotNetRuntimeStatsBuilder.Builder RuntimeStats { get; private set; }
+        public global::Prometheus.DotNetRuntime.DotNetRuntimeStatsBuilder.Builder RuntimeStats { get; private set; }
+#endif
     }
 }

--- a/src/Spiffy.Monitoring.Prometheus/PrometheusProvider.cs
+++ b/src/Spiffy.Monitoring.Prometheus/PrometheusProvider.cs
@@ -14,7 +14,9 @@ namespace Spiffy.Monitoring.Prometheus
                 var config = new PrometheusConfigurationApi();
                 customize(config);
                 _previousCollector?.Dispose();
+#if NET6_0_OR_GREATER
                 _previousCollector = config.RuntimeStats.StartCollecting();
+#endif
             }
             api.Add("prometheus", PrometheusRules.Process);
             return api;

--- a/src/Spiffy.Monitoring.Prometheus/Spiffy.Monitoring.Prometheus.csproj
+++ b/src/Spiffy.Monitoring.Prometheus/Spiffy.Monitoring.Prometheus.csproj
@@ -4,7 +4,7 @@
     <Copyright>2020-2023</Copyright>
     <Authors>Chris Peterson</Authors>
     <Description>The Prometheus provider for Spiffy.Monitoring</Description>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <AssemblyName>Spiffy.Monitoring.Prometheus</AssemblyName>
     <PackageId>Spiffy.Monitoring.Prometheus</PackageId>
     <PackageTags>monitoring;eventcontext;logging;structured logging;prometheus;splunk</PackageTags>
@@ -12,14 +12,17 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
     <RootNamespace>Spiffy.Monitoring.Prometheus</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Spiffy.Monitoring\Spiffy.Monitoring.csproj" />
-    <PackageReference Include="prometheus-net.DotNetRuntime" Version="4.4.*" />
     <PackageReference Include="prometheus-net" Version="8.0.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' " >
+    <PackageReference Include="prometheus-net.DotNetRuntime" Version="4.4.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`prometheus-net.DotNetRuntime` has always required > `netstandard2.0`

I don't want to force everyone to upgrade their target framework (they may not even care about the runtime metrics)