### PR TITLE
Better logging for async methods

### DIFF
--- a/src/Spiffy.Monitoring/Spiffy.Monitoring.csproj
+++ b/src/Spiffy.Monitoring/Spiffy.Monitoring.csproj
@@ -12,7 +12,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>6.2.3</Version>
+    <Version>6.2.4</Version>
     <RootNamespace>Spiffy.Monitoring</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/UnitTests/EventContextTests.cs
+++ b/tests/UnitTests/EventContextTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Spiffy.Monitoring;
 using Kekiri.Xunit;
@@ -24,6 +26,20 @@ namespace UnitTests
             Then(Component_and_operation_should_be, "MyComponent", "MyOperation");
         }
 
+        [Scenario]
+        public void Implicit_creation_from_async_context()
+        {
+            WhenAsync(Creating_an_event_context_async);
+            Then(Component_and_operation_should_be, GetType().Name, nameof(Creating_an_event_context_async));
+        }
+
+        [Scenario]
+        public void Created_via_reflection()
+        {
+            When(Creating_an_event_context_via_reflection);
+            Then(Component_and_operation_should_be, "RuntimeType", "CreateInstanceDefaultCtor");
+        }
+
         void Component_and_operation_should_be(string component, string operation)
         {
             var context = (EventContext)Context.EventContext;
@@ -34,6 +50,17 @@ namespace UnitTests
         void Creating_an_event_context(EventContext eventContext)
         {
             Context.EventContext = eventContext;
+        }
+
+        async Task Creating_an_event_context_async()
+        {
+            Context.EventContext = new EventContext();
+            await Task.CompletedTask;
+        }
+
+        void Creating_an_event_context_via_reflection()
+        {
+            Context.EventContext = Activator.CreateInstance(typeof(EventContext));
         }
     }
 


### PR DESCRIPTION
We already use [Ben.Demystifier](https://github.com/benaadams/Ben.Demystifier) for making human friendly stack traces when logging exceptions, use that same goodness for method names

## Before
```c#
class MyClass {
  async Task MyMethod() {
    using var eventContext = new EventContext();
  }
}
```
would result in logs like:
`Component=<MyMethodAsync>d__2 Operation=MoveNext`

## After
`Component=MyClass Operation=MyMethodAsync`

<hr />

Unrelated, but while in there, handle the case when created via reflection
