### PR TITLE
Align to latest prometheus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
       Configuration: Release 
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       
       - name: Build
         run: dotnet build

--- a/Spiffy.Monitoring.sln
+++ b/Spiffy.Monitoring.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Spiffy.Monitoring.Splunk", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Spiffy.Monitoring.Aws", "src\Spiffy.Monitoring.Aws\Spiffy.Monitoring.Aws.csproj", "{E7E90469-1E8B-4204-9990-48CD0C42E481}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestWebApp", "tests\TestWebApp\TestWebApp.csproj", "{4DF62688-C556-4439-93C1-2E4562E07F42}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +61,10 @@ Global
 		{E7E90469-1E8B-4204-9990-48CD0C42E481}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E7E90469-1E8B-4204-9990-48CD0C42E481}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E7E90469-1E8B-4204-9990-48CD0C42E481}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4DF62688-C556-4439-93C1-2E4562E07F42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4DF62688-C556-4439-93C1-2E4562E07F42}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4DF62688-C556-4439-93C1-2E4562E07F42}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4DF62688-C556-4439-93C1-2E4562E07F42}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -70,5 +76,6 @@ Global
 		{1FE31255-E41A-4A76-B819-FA1E1AA4451F} = {8DEB13B2-A275-40CB-8D0F-AA672DB5717E}
 		{9AD4DAE4-10DB-4933-9A28-6D0F994ADC17} = {8DEB13B2-A275-40CB-8D0F-AA672DB5717E}
 		{E7E90469-1E8B-4204-9990-48CD0C42E481} = {8DEB13B2-A275-40CB-8D0F-AA672DB5717E}
+		{4DF62688-C556-4439-93C1-2E4562E07F42} = {2DF31750-1635-4C57-980C-23EA82B2DE53}
 	EndGlobalSection
 EndGlobal

--- a/src/Spiffy.Monitoring.Prometheus/PrometheusConfigurationApi.cs
+++ b/src/Spiffy.Monitoring.Prometheus/PrometheusConfigurationApi.cs
@@ -1,14 +1,30 @@
+using System;
+
 namespace Spiffy.Monitoring.Prometheus
 {
     public class PrometheusConfigurationApi
     {
-#if NET6_0_OR_GREATER
+        internal bool SuppressMeters { get; private set; } = true;
+        internal bool SuppressDebugMetrics { get; private set; } = true;
+
         public PrometheusConfigurationApi()
         {
-            RuntimeStats = global::Prometheus.DotNetRuntime.DotNetRuntimeStatsBuilder.Customize();
         }
 
-        public global::Prometheus.DotNetRuntime.DotNetRuntimeStatsBuilder.Builder RuntimeStats { get; private set; }
-#endif
+
+        [Obsolete("Prometheus.DotNetRuntime is poorly maintained and has been removed from options for this library.  Consider removing, or otherwise move configuration to a different location", true)]
+        public object RuntimeStats { get ; } = null;
+
+        public PrometheusConfigurationApi EnableMeters()
+        {
+            SuppressMeters = false;
+            return this;
+        }
+        
+        public PrometheusConfigurationApi EnableDebugMetrics()
+        {
+            SuppressDebugMetrics = false;
+            return this;
+        }
     }
 }

--- a/src/Spiffy.Monitoring.Prometheus/Spiffy.Monitoring.Prometheus.csproj
+++ b/src/Spiffy.Monitoring.Prometheus/Spiffy.Monitoring.Prometheus.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Copyright>2020-2023</Copyright>
+    <Copyright>2020-2024</Copyright>
     <Authors>Chris Peterson</Authors>
     <Description>The Prometheus provider for Spiffy.Monitoring</Description>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Spiffy.Monitoring.Prometheus</AssemblyName>
     <PackageId>Spiffy.Monitoring.Prometheus</PackageId>
     <PackageTags>monitoring;eventcontext;structured logging;metrics;prometheus;splunk</PackageTags>
@@ -12,17 +12,13 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>2.0.6</Version>
+    <Version>3.0.0</Version>
     <RootNamespace>Spiffy.Monitoring.Prometheus</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Spiffy.Monitoring\Spiffy.Monitoring.csproj" />
-    <PackageReference Include="prometheus-net" Version="6.0.*" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' " >
-    <PackageReference Include="prometheus-net.DotNetRuntime" Version="4.4.*" />
+    <PackageReference Include="prometheus-net" Version="8.2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/TestConsoleApp/Program.cs
+++ b/tests/TestConsoleApp/Program.cs
@@ -92,13 +92,7 @@ namespace TestConsoleApp
                             spiffy.Providers
                                 .Trace()
                                 .Console()
-                                .Prometheus(cfg =>
-                                {
-                                    cfg.RuntimeStats
-                                        .WithGcStats()
-                                        //.WithXXX()
-                                    ;
-                                })
+                                .Prometheus()
                                 .Splunk(cfg => {})
                                 .NLog(cfg => {});
                         });

--- a/tests/TestConsoleApp/Properties/launchSettings.json
+++ b/tests/TestConsoleApp/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "TestConsoleApp": {
       "commandName": "Project",
-      "commandLineArgs": "aws",
+      "commandLineArgs": "console",
       "environmentVariables": {
         "AWS_PROFILE": "xxx"
       }

--- a/tests/TestConsoleApp/TestConsoleApp.csproj
+++ b/tests/TestConsoleApp/TestConsoleApp.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <DebugType>portable</DebugType>
         <OutputTypeEx>exe</OutputTypeEx>
     </PropertyGroup>

--- a/tests/TestWebApp/Program.cs
+++ b/tests/TestWebApp/Program.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Builder;
+using Prometheus;
+using Spiffy.Monitoring;
+using Spiffy.Monitoring.Console;
+using Spiffy.Monitoring.Prometheus;
+
+Configuration.Initialize(spiffy =>
+{
+    spiffy.Providers
+        .Console()
+        .Prometheus();
+});
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+app.UseRouting();
+
+app.MapGet("/", () => "Hello World!");
+
+app.UseEndpoints(endpoints => {
+    endpoints.MapMetrics();
+});
+
+app.Run();

--- a/tests/TestWebApp/Properties/launchSettings.json
+++ b/tests/TestWebApp/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5124",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/tests/TestWebApp/TestWebApp.csproj
+++ b/tests/TestWebApp/TestWebApp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Spiffy.Monitoring.Prometheus\Spiffy.Monitoring.Prometheus.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.*" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <DebugType>portable</DebugType>
         <ApplicationIcon />
         <OutputTypeEx>library</OutputTypeEx>


### PR DESCRIPTION
There are known bugs in 7.0, compatibility issues across target fxs, as well as some strange/dangerous default behaviors

This release aligns to 8.x for `prometheus-net` as well as .net 8 and chooses defaults that make sense for web apps