### PR TITLE
Add a safety net to avoid breaking APIs

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -1,0 +1,47 @@
+name: API Compatibility
+
+on:
+  pull_request:
+    branches: [ '*' ]
+  push:
+    branches: [ '*' ]
+
+jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      apis: ${{ steps.set-matrix.outputs.apis }}
+    steps:
+    - uses: actions/checkout@v4
+    - id: set-matrix
+      run: |
+        apis=$(jq -c '[.[].version]' apicompat/apis.json)
+        echo "apis=$apis" >> $GITHUB_OUTPUT
+
+  nuget-package:
+    runs-on: ubuntu-latest
+    needs: generate-matrix
+    strategy:
+      matrix:
+        api: ${{ fromJson(needs.generate-matrix.outputs.apis) }}
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Install Microsoft.DotNet.ApiCompat.Tool
+      run: dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Make script executable
+      run: chmod +x apicompat/test-api-compatibility.sh
+
+    - name: Run API Compatibility Check for ${{ matrix.api }}
+      run: ./apicompat/test-api-compatibility.sh ${{ matrix.api }}

--- a/apicompat/README.md
+++ b/apicompat/README.md
@@ -1,0 +1,137 @@
+# API Compatibility Testing
+
+This directory contains API compatibility testing for the Spiffy.Monitoring library using Microsoft's [`apicompat`](https://www.nuget.org/packages/Microsoft.DotNet.ApiCompat.Tool/) tool to ensure backward compatibility against multiple API versions.
+
+## Directory Structure
+
+```
+apicompat/
+├── README.md                         # This documentation
+├── apis.json                         # API versions configuration
+├── test-api-compatibility.sh         # Main compatibility test script
+└── test-api-compatibility-matrix.sh  # Matrix test runner
+```
+
+## Configuration
+
+API versions are defined in `apis.json` with structured data:
+
+```json
+[
+  {
+    "version": "6.4.6",
+    "release_date": "2025-09-22"
+  },
+  {
+    "version": "6.1.0",
+    "release_date": "2021-11-02"
+  }
+]
+```
+
+The script automatically detects the appropriate target framework (.NET Standard 2.0, .NET Standard 1.3, or .NET Framework 4.0) by probing the NuGet package structure.
+
+## Usage
+
+### Local Testing
+
+**Test all API versions:**
+```bash
+# Install the Microsoft apicompat tool
+dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool
+
+# Test all versions (summary output)
+./apicompat/test-api-compatibility.sh
+
+# Test all versions (detailed progress)
+./apicompat/test-api-compatibility-matrix.sh
+```
+
+**Test a specific version:**
+```bash
+./apicompat/test-api-compatibility.sh 6.3.1
+```
+
+The scripts automatically:
+- Build the current version of Spiffy.Monitoring
+- Download specified API versions from NuGet  
+- Run compatibility analysis using Microsoft's tool
+- Report any breaking changes with detailed output
+
+### Suppression Files
+
+Each suppression file contains known breaking changes for a specific API version that have been reviewed and accepted. These files are in Microsoft's standard XML suppression format and contain:
+
+- **DiagnosticId**: The type of compatibility issue (e.g., CP0002 for missing members)
+- **Target**: The specific API member that changed
+
+Example suppression file:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Spiffy.Monitoring.Config.InitializationApi.ProvidersApi.#ctor(Spiffy.Monitoring.Config.InitializationApi)</Target>
+  </Suppression>
+</Suppressions>
+```
+
+## Usage
+
+### Local Testing
+
+**Test all APIs:**
+```bash
+# Make sure the tool is installed
+dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool
+
+# Quick test (shows summary only)
+././apicompat/test-api-compatibility.sh
+
+# Detailed test with progress indicators
+././apicompat/test-api-compatibility-matrix.sh
+```
+
+**Test a specific API:**
+```bash
+././apicompat/test-api-compatibility.sh 6.1.0
+```
+
+## Handling Breaking Changes  
+
+When compatibility tests detect breaking changes, review the detailed output to understand what changed. Since this project maintains strict backward compatibility, any breaking changes should be addressed by fixing the implementation rather than suppressing the issues.
+
+The Microsoft.DotNet.ApiCompat.Tool provides detailed diagnostic information including:
+- Missing types or members
+- Signature changes
+- Accessibility changes
+- Breaking changes across assemblies
+
+### Manual Testing
+
+For manual testing or debugging, you can run the Microsoft apicompat tool directly:
+
+```bash
+# Build the current version
+dotnet build src/Spiffy.Monitoring/Spiffy.Monitoring.csproj --configuration Release
+
+# Test against a specific API version (example: 6.1.0)
+apicompat \
+  --left ~/.nuget/packages/spiffy.monitoring/6.1.0/lib/netstandard2.0/Spiffy.Monitoring.dll \
+  --right ./src/Spiffy.Monitoring/bin/Release/netstandard2.0/Spiffy.Monitoring.dll
+```
+
+## Troubleshooting
+
+**"No API found for version X.X.X"**
+- The script automatically downloads packages from NuGet
+- Ensure internet connectivity and that the version exists in NuGet package history
+
+**"Command not found: apicompat"** 
+- Install the tool globally: `dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool`
+
+**Build issues**
+- Ensure the project builds successfully before running compatibility tests
+- Check that the output directory contains the expected assemblies
+
+The matrix test runner provides visual progress indicators, clear separation between API tests, and comprehensive pass/fail summaries for easy debugging.

--- a/apicompat/apis.json
+++ b/apicompat/apis.json
@@ -1,0 +1,78 @@
+[
+  {
+    "version": "6.4.6",
+    "release_date": "2025-09-22"
+  },
+  {
+    "version": "6.4.2",
+    "release_date": "2025-05-12"
+  },
+  {
+    "version": "6.4.1",
+    "release_date": "2025-05-12"
+  },
+  {
+    "version": "6.4.0",
+    "release_date": "2025-04-03"
+  },
+  {
+    "version": "6.3.1",
+    "release_date": "2024-01-03"
+  },
+  {
+    "version": "6.3.0",
+    "release_date": "2023-10-20"
+  },
+  {
+    "version": "6.2.6",
+    "release_date": "2023-06-12"
+  },
+  {
+    "version": "6.2.5",
+    "release_date": "2023-05-10"
+  },
+  {
+    "version": "6.2.4",
+    "release_date": "2023-04-27"
+  },
+  {
+    "version": "6.2.3",
+    "release_date": "2023-01-18"
+  },
+  {
+    "version": "6.2.2",
+    "release_date": "2023-01-06"
+  },
+  {
+    "version": "6.2.1",
+    "release_date": "2023-01-06"
+  },
+  {
+    "version": "6.2.0",
+    "release_date": "2022-05-02"
+  },
+  {
+    "version": "6.1.0",
+    "release_date": "2021-11-02"
+  },
+  {
+    "version": "6.0.8",
+    "release_date": "2021-08-09"
+  },
+  {
+    "version": "6.0.7",
+    "release_date": "2021-06-15"
+  },
+  {
+    "version": "6.0.6",
+    "release_date": "2020-11-12"
+  },
+  {
+    "version": "6.0.5",
+    "release_date": "2020-11-10"
+  },
+  {
+    "version": "6.0.3",
+    "release_date": "2020-10-30"
+  }
+]

--- a/apicompat/test-api-compatibility-matrix.sh
+++ b/apicompat/test-api-compatibility-matrix.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# API Compatibility Test Matrix Runner
+# Runs compatibility tests against all API versions defined in apis.json
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+APIS_FILE="$PROJECT_ROOT/apicompat/apis.json"
+TEST_SCRIPT="$PROJECT_ROOT/apicompat/test-api-compatibility.sh"
+
+echo "🔍 API Compatibility Matrix Test Runner"
+echo "========================================"
+echo ""
+
+# Check if required files exist
+if [ ! -f "$APIS_FILE" ]; then
+    echo "❌ ERROR: Baselines config file not found: $APIS_FILE"
+    exit 1
+fi
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+    echo "❌ ERROR: Test script not found: $TEST_SCRIPT"
+    exit 1
+fi
+
+# Load API versions from JSON file
+echo "📋 Loading API versions from $APIS_FILE..."
+APIS=()
+while IFS= read -r version; do
+    if [[ -n "$version" ]]; then
+        APIS+=("$version")
+        echo "   Found API: $version"
+    fi
+done < <(jq -r '.[].version' "$APIS_FILE")
+
+if [ ${#APIS[@]} -eq 0 ]; then
+    echo "❌ ERROR: No API versions found in $APIS_FILE"
+    exit 1
+fi
+
+echo ""
+echo "🚀 Running compatibility tests against ${#APIS[@]} API versions..."
+echo ""
+
+# Track results
+TOTAL_TESTS=${#APIS[@]}
+PASSED_TESTS=0
+FAILED_TESTS=0
+declare -a FAILED_APIS
+
+# Run test for each API version
+for api_version in "${APIS[@]}"; do
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "🔍 Testing API version: $api_version"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    
+    if "$TEST_SCRIPT" "$api_version"; then
+        echo "✅ $api_version: PASSED"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+    else
+        echo "❌ $api_version: FAILED"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+        FAILED_APIS+=("$api_version")
+    fi
+    
+    echo ""
+done
+
+# Final summary
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📊 FINAL RESULTS"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Total API versions tested: $TOTAL_TESTS"
+echo "✅ Passed: $PASSED_TESTS"
+echo "❌ Failed: $FAILED_TESTS"
+
+if [ $FAILED_TESTS -gt 0 ]; then
+    echo ""
+    echo "Failed API versions:"
+    for failed_api_version in "${FAILED_APIS[@]}"; do
+        echo "  - $failed_api_version"
+    done
+    echo ""
+    echo "💡 To debug individual failures, run:"
+    for failed_api_version in "${FAILED_APIS[@]}"; do
+        echo "   $TEST_SCRIPT $failed_api_version"
+    done
+    echo ""
+    echo "❌ Some compatibility tests failed!"
+    exit 1
+else
+    echo ""
+    echo "🎉 All compatibility tests passed!"
+    exit 0
+fi

--- a/apicompat/test-api-compatibility.sh
+++ b/apicompat/test-api-compatibility.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+set -e
+
+# Get the directory of this script and project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+APIS_FILE="$PROJECT_ROOT/apicompat/apis.json"
+
+# Load API versions from JSON config
+load_apis_from_config() {
+    DEFAULT_APIS=()
+    if [ -f "$APIS_FILE" ]; then
+        # Extract versions using jq
+        while IFS= read -r version; do
+            if [[ -n "$version" ]]; then
+                DEFAULT_APIS+=("$version")
+            fi
+        done < <(jq -r '.[].version' "$APIS_FILE")
+    fi
+    
+    # Exit if config file not found or empty
+    if [ ${#DEFAULT_APIS[@]} -eq 0 ]; then
+        echo "❌ ERROR: Could not load APIs from $APIS_FILE"
+        echo "Please ensure the file exists and contains valid JSON."
+        exit 1
+    fi
+}
+
+# Load APIs from config
+load_apis_from_config
+
+# Allow specifying a single API version via command line argument
+if [ $# -eq 1 ]; then
+    APIS=("$1")
+    echo "🔍 API Compatibility Testing (Single API: $1)"
+else
+    APIS=("${DEFAULT_APIS[@]}")
+    echo "🔍 API Compatibility Testing (All APIs)"
+fi
+
+echo "============================="
+echo ""
+
+# Check if Microsoft.DotNet.ApiCompat.Tool is installed
+if ! command -v apicompat &> /dev/null; then
+    echo "Installing Microsoft.DotNet.ApiCompat.Tool..."
+    dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool
+    echo ""
+fi
+
+# Build the current version
+echo "📦 Building current version..."
+dotnet build src/Spiffy.Monitoring/Spiffy.Monitoring.csproj --configuration Release --no-restore
+echo ""
+
+# Create a temporary directory for baselines
+TEMP_DIR=$(mktemp -d)
+echo "📁 Using temporary directory: $TEMP_DIR"
+echo ""
+
+# Function to cleanup on exit
+cleanup() {
+    echo "🧹 Cleaning up temporary directory..."
+    rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+# Test each baseline version
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+for api_version in "${APIS[@]}"; do
+    echo "🔍 Testing against API version $api_version..."
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    
+    # Download the API version
+    api_dir="$TEMP_DIR/apis/$api_version"
+    mkdir -p "$api_dir"
+    cd "$api_dir"
+    
+    # Create a temporary project to download the specific version
+    dotnet new console -n TempApp --force > /dev/null 2>&1
+    cd TempApp
+    
+    # Add the specific version of Spiffy.Monitoring
+    dotnet add package Spiffy.Monitoring --version "$api_version" > /dev/null 2>&1
+    dotnet restore > /dev/null 2>&1
+    
+    # Find the assembly - all current APIs use netstandard2.0
+    api_dll=$(find ~/.nuget/packages/spiffy.monitoring/$api_version -name "Spiffy.Monitoring.dll" -path "*/netstandard2.0/*" | head -1)
+    
+    if [ -z "$api_dll" ]; then
+        echo "❌ ERROR: Could not find Spiffy.Monitoring.dll for version $api_version"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+        continue
+    fi
+    
+    # Go back to the project root for apicompat execution
+    cd "$PROJECT_ROOT"
+    
+    # Build apicompat command with absolute paths
+    current_dll="$PROJECT_ROOT/src/Spiffy.Monitoring/bin/Release/netstandard2.0/Spiffy.Monitoring.dll"
+    apicompat_cmd="apicompat --left \"$api_dll\" --right \"$current_dll\""
+    
+    # Run the compatibility check (disable exit on error temporarily)
+    echo "   Running apicompat check..."
+    set +e
+    apicompat_output=$(eval "$apicompat_cmd" 2>&1)
+    apicompat_exit_code=$?
+    set -e
+    
+    if [ $apicompat_exit_code -eq 0 ]; then
+        echo "   ✅ PASS"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+    else
+        echo "   ❌ FAIL - API breaking changes detected"
+        echo ""
+        echo "   🔍 API Compatibility Issues:"
+        echo "$apicompat_output" | sed 's/^/      /'
+        echo ""
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+    fi
+    echo ""
+done
+
+# Summary
+echo "📊 Summary"
+echo "=========="
+echo "Total tests: $TOTAL_TESTS"
+echo "Passed: $PASSED_TESTS"
+echo "Failed: $FAILED_TESTS"
+
+if [ $FAILED_TESTS -gt 0 ]; then
+    echo ""
+    echo "❌ Some compatibility tests failed!"
+    exit 1
+else
+    echo ""
+    echo "✅ All compatibility tests passed!"
+fi

--- a/src/Spiffy.Monitoring/BackwardsCompatabilityShims.cs
+++ b/src/Spiffy.Monitoring/BackwardsCompatabilityShims.cs
@@ -1,17 +1,17 @@
-// this file exists to preserve previous API artifacts (version 5.2.0 and earlier)
-// (https://github.com/chris-peterson/spiffy/blob/8ec62fde0a8658b8c511ecb2d4f3a9b393dd2988/src/Spiffy.Monitoring/ExtensionMethods.cs)
-// if these extensions were to be removed, applications built against earlier versions
-// would experience runtime errors, e.g.:
-// System.TypeLoadException: Could not load type 'Spiffy.Monitoring.ExceptionExtensions' from
-// assembly 'Spiffy.Monitoring, Version=6.0.0.0, Culture=neutral, PublicKeyToken=null'.
-//
-// given there are likely many library assemblies (as opposed to edge assemblies) that
-// couple to this library, requiring them all to re-compile is untenable
+// this file exists to preserve previous API artifacts
 
 using System;
 
 namespace Spiffy.Monitoring
 {
+    // (https://github.com/chris-peterson/spiffy/blob/8ec62fde0a8658b8c511ecb2d4f3a9b393dd2988/src/Spiffy.Monitoring/ExtensionMethods.cs)
+    // if these extensions were to be removed, applications built against earlier versions
+    // would experience runtime errors, e.g.:
+    // System.TypeLoadException: Could not load type 'Spiffy.Monitoring.ExceptionExtensions' from
+    // assembly 'Spiffy.Monitoring, Version=6.0.0.0, Culture=neutral, PublicKeyToken=null'.
+    //
+    // given there are likely many library assemblies (as opposed to edge assemblies) that
+    // couple to this library, requiring them all to re-compile is untenable
     public static class ExceptionExtensions
     {
         [Obsolete("This extension should be avoided, instead preferring IncludeException on EventContext")]
@@ -33,6 +33,79 @@ namespace Spiffy.Monitoring
         public static EventContext IncludeStructure(this EventContext eventContext, object structure, string keyPrefix = null, bool includeNullValues = false)
         {
             return eventContext.IncludeStructure(structure, keyPrefix, includeNullValues);
+        }
+    }
+}
+
+namespace Spiffy.Monitoring.Config
+{
+    // Preserving these public constructors
+    // I don't expect anyone to have used them as there wouldn't be much point,
+    // but keeping to preserve full API compatibility until 7.x
+    public partial class InitializationApi
+    {
+        /// <summary>
+        /// If set, this value is used for logging values that are null.
+        /// </summary>
+        [Obsolete("superseded by Formatting.NullValue")]
+        public string CustomNullValue { get; set; }
+
+        /// <summary>
+        /// Whether to remove newline characters from logged values.
+        /// </summary>
+        /// <returns>
+        /// <code>true</code> if newline characters will be removed from logged
+        /// values, <code>false</code> otherwise.
+        /// </returns>
+        [Obsolete("superseded by Formatting.Newlines")]
+        public bool RemoveNewlines { get; set; } = false;
+
+        /// <summary>
+        /// Values over this length will be deprioritized in the <see cref="LogEvent.Message"/>.
+        /// Defaults to 1024.
+        /// </summary>
+        /// <remarks>
+        /// In some logging scenarios, long values can result in some key/value pairs being cut off.
+        /// Key/value pairs with values whose length exceeds this value will be output after those
+        /// pairs whose values do not.
+        /// </remarks>
+        [Obsolete("superseded by Formatting.DeprioritizeValueLength")]
+        public int DeprioritizedValueLength { get; set; } = -1;
+
+        public partial class CallbacksApi
+        {
+            [Obsolete("This class is not intended for public use.  It will go away in future versions")]
+            public CallbacksApi(InitializationApi parent)
+            {
+            }
+        }
+        public partial class FormattingApi
+        {
+            [Obsolete("This class is not intended for public use.  It will go away in future versions")]
+            public FormattingApi(InitializationApi parent)
+            {
+            }
+        }
+        public partial class NamingApi
+        {
+            [Obsolete("This class is not intended for public use.  It will go away in future versions")]
+            public NamingApi(InitializationApi parent)
+            {
+            }
+
+
+            [Obsolete("superseded by ShortFieldNames")]
+            public void UseShortFieldNames()
+            {
+                ShortFieldNames();
+            }
+        }
+        public partial class ProvidersApi
+        {
+            [Obsolete("This class is not intended for public use.  It will go away in future versions")]
+            public ProvidersApi(InitializationApi parent)
+            {
+            }
         }
     }
 }

--- a/src/Spiffy.Monitoring/Config/InitializationApi.cs
+++ b/src/Spiffy.Monitoring/Config/InitializationApi.cs
@@ -5,11 +5,17 @@ using Spiffy.Monitoring.Config.Naming;
 
 namespace Spiffy.Monitoring.Config
 {
-    public class InitializationApi
+    public partial class InitializationApi
     {
         // Custom providers should extend this API by way of extension methods
-        public class ProvidersApi()
+
+        public partial class ProvidersApi
         {
+            // TODO: this should be internal
+            public ProvidersApi()
+            {
+            }
+
             internal readonly Dictionary<string, Action<LogEvent>> LoggingActions = new();
             public void Add(string id, Action<LogEvent> loggingAction)
             {
@@ -17,8 +23,13 @@ namespace Spiffy.Monitoring.Config
             }
         }
 
-        public class CallbacksApi()
+        public partial class CallbacksApi
         {
+            // TODO: this should be internal
+            public CallbacksApi()
+            {
+            }
+
             internal readonly List<Action<EventContext>> BeforeLoggingActions = new();
             public void BeforeLogging(Action<EventContext> action)
             {
@@ -26,12 +37,11 @@ namespace Spiffy.Monitoring.Config
             }
         }
 
-        public class NamingApi()
+        public partial class NamingApi
         {
-            [Obsolete("superseded by ShortFieldNames")]
-            public void UseShortFieldNames()
+            // TODO: this should be internal
+            public NamingApi()
             {
-                ShortFieldNames();
             }
 
             public NamingApi ShortFieldNames()
@@ -50,8 +60,13 @@ namespace Spiffy.Monitoring.Config
             internal TimestampNaming? TimestampNaming { get; private set; }
         }
 
-        public class FormattingApi()
+        public partial class FormattingApi
         {
+            // TODO: this should be internal
+            public FormattingApi()
+            {
+            }
+
             public FormattingApi SpecialValue(SpecialValueFormatting formatting)
             {
                 SpecialValueFormatting = formatting;
@@ -100,37 +115,9 @@ namespace Spiffy.Monitoring.Config
             Formatting = new FormattingApi();
         }
 
-        /// <summary>
-        /// If set, this value is used for logging values that are null.
-        /// </summary>
-        [Obsolete("superseded by Formatting.NullValue")]
-        public string CustomNullValue { get; set; }
-
         public NamingApi Naming { get; }
 
         public FormattingApi Formatting { get; }
-
-        /// <summary>
-        /// Whether to remove newline characters from logged values.
-        /// </summary>
-        /// <returns>
-        /// <code>true</code> if newline characters will be removed from logged
-        /// values, <code>false</code> otherwise.
-        /// </returns>
-        [Obsolete("superseded by Formatting.Newlines")]
-        public bool RemoveNewlines { get; set; } = false;
-
-        /// <summary>
-        /// Values over this length will be deprioritized in the <see cref="LogEvent.Message"/>.
-        /// Defaults to 1024.
-        /// </summary>
-        /// <remarks>
-        /// In some logging scenarios, long values can result in some key/value pairs being cut off.
-        /// Key/value pairs with values whose length exceeds this value will be output after those
-        /// pairs whose values do not.
-        /// </remarks>
-        [Obsolete("superseded by Formatting.DeprioritizeValueLength")]
-        public int DeprioritizedValueLength { get; set; } = -1;
 
         public InitializationApi UseLogfmt()
         {


### PR DESCRIPTION
After some unexpected churn with `6.4.3` - `6.4.7`, adding in a CI job to protect against API regressions

kudos [:copilot: with Claude Sonnet 4](https://www.anthropic.com/claude/sonnet) for writing 100% of the code

(though, I wrote _way_ more text in prompts)