### PR TITLE
Publish symbol packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,9 @@ jobs:
         run: dotnet build
         
       - name: Publish to nuget.org
-        run: dotnet nuget push **/*.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: |
+          dotnet nuget push **/*.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push **/*.snupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
         
     environment:
       name: nuget.org

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+</Project>

--- a/src/Spiffy.Monitoring.Aws/Spiffy.Monitoring.Aws.csproj
+++ b/src/Spiffy.Monitoring.Aws/Spiffy.Monitoring.Aws.csproj
@@ -5,7 +5,6 @@
         <Authors>Chris Peterson</Authors>
         <Description>AWS provider for Spiffy.Monitoring</Description>
         <TargetFrameworks>netstandard2.0</TargetFrameworks>
-        <DebugType>portable</DebugType>
         <AssemblyName>Spiffy.Monitoring.Aws</AssemblyName>
         <PackageId>Spiffy.Monitoring.Aws</PackageId>
         <PackageTags>monitoring;eventcontext;structured logging;aws</PackageTags>

--- a/src/Spiffy.Monitoring.NLog/Spiffy.Monitoring.NLog.csproj
+++ b/src/Spiffy.Monitoring.NLog/Spiffy.Monitoring.NLog.csproj
@@ -5,7 +5,6 @@
     <Authors>Chris Peterson</Authors>
     <Description>The NLog adapter for Spiffy.Monitoring</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <DebugType>portable</DebugType>
     <AssemblyName>Spiffy.Monitoring.NLog</AssemblyName>
     <PackageId>Spiffy.Monitoring.NLog</PackageId>
     <PackageTags>monitoring;eventcontext;structured logging;nlog</PackageTags>

--- a/src/Spiffy.Monitoring.Splunk/Spiffy.Monitoring.Splunk.csproj
+++ b/src/Spiffy.Monitoring.Splunk/Spiffy.Monitoring.Splunk.csproj
@@ -5,7 +5,6 @@
     <Authors>Chris Peterson</Authors>
     <Description>The Splunk provider for Spiffy.Monitoring</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <DebugType>portable</DebugType>
     <AssemblyName>Spiffy.Monitoring.Splunk</AssemblyName>
     <PackageId>Spiffy.Monitoring.Splunk</PackageId>
     <PackageTags>monitoring;eventcontext;structured logging;splunk</PackageTags>

--- a/src/Spiffy.Monitoring/Spiffy.Monitoring.csproj
+++ b/src/Spiffy.Monitoring/Spiffy.Monitoring.csproj
@@ -5,7 +5,6 @@
     <Authors>Chris Peterson</Authors>
     <Description>A monitoring framework for .NET that supports IoC and modern targets, e.g. Splunk</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DebugType>portable</DebugType>
     <AssemblyName>Spiffy.Monitoring</AssemblyName>
     <PackageId>Spiffy.Monitoring</PackageId>
     <PackageTags>monitoring;eventcontext;structured logging;nlog;splunk;prometheus</PackageTags>


### PR DESCRIPTION
## Summary

- Add Source Link and symbol package (.snupkg) support for all NuGet packages
- Symbols are published to the nuget.org symbol server, enabling step-into debugging for consumers
- Remove redundant `<DebugType>portable</DebugType>` from csproj files (already the default)

### How it works

As of .NET SDK 8, [Source Link is built into the SDK](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link) — no package reference needed. The SDK automatically embeds source control metadata in PDBs, mapping source files to the exact GitHub commit.

The new `Directory.Build.props` configures:
- **`PublishRepositoryUrl`** — publishes the repo URL in NuGet package metadata ([must be explicitly opted-in](https://github.com/dotnet/sourcelink/issues/1203))
- **`IncludeSymbols` / `SymbolPackageFormat=snupkg`** — generates separate symbol packages ([recommended over embedded PDBs](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#symbol-packages) to avoid ~30% package size bloat)
- **`ContinuousIntegrationBuild`** — normalizes file paths in PDBs on CI so they work across machines

### What consumers get

Debugger (VS/Rider) automatically downloads PDBs from the nuget.org symbol server, then Source Link fetches the matching source from GitHub on demand.

### References

- [Source Link docs](https://github.com/dotnet/sourcelink/blob/main/docs/README.md)
- [.NET library guidance: NuGet](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/nuget)
- [NuGet package authoring best practices](https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices)

## Test plan

- [x] Verify snupkg files are generated alongside nupkg during build
- [x] Verify publish workflow pushes both nupkg and snupkg to nuget.org
- [x] Revert `sourcelink` branch trigger from publish.yml before merge
