### PR TITLE
Filter AWS SDK trace noise by default

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Install Microsoft.DotNet.ApiCompat.Tool
       run: dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       
       - name: Build
         run: dotnet build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Build
         run: dotnet build

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -38,6 +38,61 @@ static void Main() {
 }
 ```
 
+### AWS Provider
+
+```bash
+PM> Install-Package Spiffy.Monitoring.Aws
+```
+
+Routes the AWS SDK's own diagnostics into your structured logs as `Component=AwsSdk Operation=Event`.
+
+```csharp
+static void Main() {
+    Spiffy.Monitoring.Configuration.Initialize(spiffy => {
+        spiffy.Providers.Aws();
+    });
+}
+```
+
+Each event's level comes from the severity the SDK reported it at.
+
+Where the SDK hands the exception to the trace listener, it is broken out into `Exception_*` fields.
+Only v3 of the AWS SDK does so — v4 discards the exception before the listener sees it, keeping only
+the message text — so don't build alerting on `Exception_*` for a v4 application.
+
+The SDK reports a lot at informational severity, including several messages that repeat on every call
+and carry nothing actionable — its own user-agent string, request-signing canonicalization, retry
+bookkeeping, buffer resizing, cached DynamoDB table descriptions, and one line per unset `AWS_*`
+environment variable. Those are suppressed by default; anything the SDK reports at warning or above
+never is.
+
+Retry and failure notices are kept, including the ones the SDK reports at informational severity —
+a throttled DynamoDB request or a rejected S3 request still reaches your logs.
+
+To suppress more, match on the start of the message:
+
+```csharp
+spiffy.Providers.Aws(c => c.SuppressMessages.Add("Resolved endpoint"));
+```
+
+`Only` replaces the defaults rather than adding to them:
+
+```csharp
+spiffy.Providers.Aws(c => c.SuppressMessages.Only("Resolved endpoint"));
+```
+
+`None` emits everything the SDK reports, noise included:
+
+```csharp
+spiffy.Providers.Aws(c => c.SuppressMessages.None());
+```
+
+Response bodies are logged on error only. `Always` logs them for every call, `Never` for none:
+
+```csharp
+spiffy.Providers.Aws(c => c.LogResponses.Always());
+```
+
 ## Multiple Providers
 
 Multiple providers can be supplied, for example, this application uses both `Console` (built-in), as well as `File` (NLog)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -57,34 +57,36 @@ static void Main() {
 Each event's level comes from the severity the SDK reported it at.
 
 Where the SDK hands the exception to the trace listener, it is broken out into `Exception_*` fields.
-Only v3 of the AWS SDK does so — v4 discards the exception before the listener sees it, keeping only
-the message text — so don't build alerting on `Exception_*` for a v4 application.
+Only v3 of the AWS SDK does so: v4 discards the exception before the listener sees it, keeping only
+the message text. So don't build alerting on `Exception_*` for a v4 application.
 
 The SDK reports a lot at informational severity, including several messages that repeat on every call
-and carry nothing actionable — its own user-agent string, request-signing canonicalization, retry
-bookkeeping, buffer resizing, cached DynamoDB table descriptions, and one line per unset `AWS_*`
-environment variable. Those are suppressed by default; anything the SDK reports at warning or above
-never is.
+and carry nothing actionable: its own user-agent string, request-signing canonicalization, retry
+bookkeeping, buffer resizing, DynamoDB table descriptions, and one line per unset `AWS_*` environment
+variable. Those are filtered by default; anything the SDK reports at warning or above never is.
 
-Retry and failure notices are kept, including the ones the SDK reports at informational severity —
+Retry and failure notices are kept, including the ones the SDK reports at informational severity, so
 a throttled DynamoDB request or a rejected S3 request still reaches your logs.
 
-To suppress more, match on the start of the message:
+There's one filter per kind, and each kind is a member of `SdkNoise`, so you don't have to know the
+message text. Remove a filter and that kind shows up in your logs again:
 
 ```csharp
-spiffy.Providers.Aws(c => c.SuppressMessages.Add("Resolved endpoint"));
+spiffy.Providers.Aws(c => c.NoiseFilters.Remove(SdkNoise.UserAgentHeader));
 ```
 
-`Only` replaces the defaults rather than adding to them:
+To filter noise `SdkNoise` doesn't name (something specific to your application, or a message a
+newer SDK started reporting), add a filter matching the start of the message:
 
 ```csharp
-spiffy.Providers.Aws(c => c.SuppressMessages.Only("Resolved endpoint"));
+spiffy.Providers.Aws(c => c.NoiseFilters.Add("Credentials found using"));
 ```
 
-`None` emits everything the SDK reports, noise included:
+`Clear` removes every filter, so everything the SDK reports is logged. Useful when you're working out
+what to filter:
 
 ```csharp
-spiffy.Providers.Aws(c => c.SuppressMessages.None());
+spiffy.Providers.Aws(c => c.NoiseFilters.Clear());
 ```
 
 Response bodies are logged on error only. `Always` logs them for every call, `Never` for none:

--- a/src/Spiffy.Monitoring.Aws/AwsConfigurationApi.cs
+++ b/src/Spiffy.Monitoring.Aws/AwsConfigurationApi.cs
@@ -25,58 +25,110 @@ namespace Spiffy.Monitoring.Aws
         }
     }
 
-    public class SuppressedMessagesApi
+    /// <summary>
+    /// The kinds of message the AWS SDK reports on every call that say nothing a reader can act on.
+    /// Every kind is filtered by default; see <see cref="NoiseFiltersApi"/>.
+    /// </summary>
+    public enum SdkNoise
     {
-        // The SDK reports these at Information/Verbose on every call, and none of them
-        // is actionable.  Anything the SDK reports at Warning or above is never suppressed.
-        internal IReadOnlyList<string> Prefixes { get; private set; } = new[]
+        /// <summary>Reported for all configurations (legacy/standard/etc).</summary>
+        DefaultConfigurationMode,
+
+        /// <summary>Routine DynamoDB usage, once per table description the SDK loads, cached or not.</summary>
+        TableDescription,
+
+        /// <summary>One line per unset variable, on every client construction.</summary>
+        UnsetEnvironmentVariables,
+
+        /// <summary>One per call, restating the SDK's own user agent.</summary>
+        UserAgentHeader,
+
+        /// <summary>Internal buffer growth while (de)serializing.</summary>
+        BufferResizing,
+
+        /// <summary>Internal retry bookkeeping, one per handled error.</summary>
+        RetryBookkeeping,
+
+        /// <summary>Request signing, one per call, carrying the request path.</summary>
+        RequestCanonicalization
+    }
+
+    public class NoiseFiltersApi
+    {
+        // Ordered so Prefixes is deterministic.  A kind can cover more than one prefix -- the
+        // SDK reports canonicalization as both "Single encoded" and "Double encoded".
+        static readonly KeyValuePair<SdkNoise, string[]>[] KnownNoise =
         {
-            // emitted for all configurations (legacy/standard/etc)
-            "Resolved DefaultConfigurationMode for RegionEndpoint",
-            // routine DynamoDB usage, once per cached table description
-            "Description for table",
-            // one per unset variable, on every client construction
-            "The environment variable ",
-            // one per call, restating the SDK's own user agent
-            "User-Agent Header",
-            // internal buffer growth
-            "Resizing buffer",
-            // internal retry bookkeeping, one per handled error
-            "Retry check: ",
-            // request signing, one per call, carrying the request path
-            "Single encoded ",
-            "Double encoded "
+            Known(SdkNoise.DefaultConfigurationMode, "Resolved DefaultConfigurationMode for RegionEndpoint"),
+            Known(SdkNoise.TableDescription, "Description for table"),
+            Known(SdkNoise.UnsetEnvironmentVariables, "The environment variable "),
+            Known(SdkNoise.UserAgentHeader, "User-Agent Header"),
+            Known(SdkNoise.BufferResizing, "Resizing buffer"),
+            Known(SdkNoise.RetryBookkeeping, "Retry check: "),
+            Known(SdkNoise.RequestCanonicalization, "Single encoded ", "Double encoded ")
         };
 
+        static KeyValuePair<SdkNoise, string[]> Known(SdkNoise kind, params string[] prefixes)
+        {
+            return new KeyValuePair<SdkNoise, string[]>(kind, prefixes);
+        }
+
+        readonly HashSet<SdkNoise> _kinds = new HashSet<SdkNoise>(KnownNoise.Select(known => known.Key));
+        readonly List<string> _prefixes = new List<string>();
+
+        // Only Information and Verbose are filtered against these; Warning and above always
+        // reach the log regardless of what's configured here.
+        internal IReadOnlyList<string> Prefixes =>
+            KnownNoise
+                .Where(known => _kinds.Contains(known.Key))
+                .SelectMany(known => known.Value)
+                .Concat(_prefixes)
+                .ToArray();
+
         /// <summary>
-        /// Suppresses messages starting with <paramref name="prefixes"/>, in addition to whatever
-        /// is already suppressed (the defaults, unless <see cref="Only"/> or <see cref="None"/> ran first).
+        /// Also filters <paramref name="kinds"/>, on top of whatever is already filtered.
+        /// </summary>
+        public void Add(params SdkNoise[] kinds)
+        {
+            foreach (var kind in kinds)
+            {
+                _kinds.Add(kind);
+            }
+        }
+
+        /// <summary>
+        /// Also filters messages starting with <paramref name="prefixes"/> -- for noise spiffy
+        /// doesn't know about, which <see cref="SdkNoise"/> can't name.
         /// </summary>
         public void Add(params string[] prefixes)
         {
-            Prefixes = Prefixes.Concat(prefixes ?? Array.Empty<string>()).ToArray();
+            _prefixes.AddRange(prefixes);
         }
 
         /// <summary>
-        /// Suppresses only messages starting with <paramref name="prefixes"/>, discarding the defaults.
+        /// Stops filtering <paramref name="kinds"/>, so those messages are logged again.
         /// </summary>
-        public void Only(params string[] prefixes)
+        public void Remove(params SdkNoise[] kinds)
         {
-            Prefixes = (prefixes ?? Array.Empty<string>()).ToArray();
+            foreach (var kind in kinds)
+            {
+                _kinds.Remove(kind);
+            }
         }
 
         /// <summary>
-        /// Emits every message the SDK reports, including the noise the defaults suppress.
+        /// Filters nothing, so every message the SDK reports is logged.
         /// </summary>
-        public void None()
+        public void Clear()
         {
-            Prefixes = Array.Empty<string>();
+            _kinds.Clear();
+            _prefixes.Clear();
         }
     }
 
     public class AwsConfigurationApi
     {
         public ResponseLoggingApi LogResponses { get; } = new ResponseLoggingApi();
-        public SuppressedMessagesApi SuppressMessages { get; } = new SuppressedMessagesApi();
+        public NoiseFiltersApi NoiseFilters { get; } = new NoiseFiltersApi();
     }
 }

--- a/src/Spiffy.Monitoring.Aws/AwsConfigurationApi.cs
+++ b/src/Spiffy.Monitoring.Aws/AwsConfigurationApi.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Amazon;
 
 namespace Spiffy.Monitoring.Aws
@@ -23,8 +25,58 @@ namespace Spiffy.Monitoring.Aws
         }
     }
 
+    public class SuppressedMessagesApi
+    {
+        // The SDK reports these at Information/Verbose on every call, and none of them
+        // is actionable.  Anything the SDK reports at Warning or above is never suppressed.
+        internal IReadOnlyList<string> Prefixes { get; private set; } = new[]
+        {
+            // emitted for all configurations (legacy/standard/etc)
+            "Resolved DefaultConfigurationMode for RegionEndpoint",
+            // routine DynamoDB usage, once per cached table description
+            "Description for table",
+            // one per unset variable, on every client construction
+            "The environment variable ",
+            // one per call, restating the SDK's own user agent
+            "User-Agent Header",
+            // internal buffer growth
+            "Resizing buffer",
+            // internal retry bookkeeping, one per handled error
+            "Retry check: ",
+            // request signing, one per call, carrying the request path
+            "Single encoded ",
+            "Double encoded "
+        };
+
+        /// <summary>
+        /// Suppresses messages starting with <paramref name="prefixes"/>, in addition to whatever
+        /// is already suppressed (the defaults, unless <see cref="Only"/> or <see cref="None"/> ran first).
+        /// </summary>
+        public void Add(params string[] prefixes)
+        {
+            Prefixes = Prefixes.Concat(prefixes ?? Array.Empty<string>()).ToArray();
+        }
+
+        /// <summary>
+        /// Suppresses only messages starting with <paramref name="prefixes"/>, discarding the defaults.
+        /// </summary>
+        public void Only(params string[] prefixes)
+        {
+            Prefixes = (prefixes ?? Array.Empty<string>()).ToArray();
+        }
+
+        /// <summary>
+        /// Emits every message the SDK reports, including the noise the defaults suppress.
+        /// </summary>
+        public void None()
+        {
+            Prefixes = Array.Empty<string>();
+        }
+    }
+
     public class AwsConfigurationApi
     {
         public ResponseLoggingApi LogResponses { get; } = new ResponseLoggingApi();
+        public SuppressedMessagesApi SuppressMessages { get; } = new SuppressedMessagesApi();
     }
 }

--- a/src/Spiffy.Monitoring.Aws/AwsProvider.cs
+++ b/src/Spiffy.Monitoring.Aws/AwsProvider.cs
@@ -15,7 +15,7 @@ namespace Spiffy.Monitoring.Aws
             configure?.Invoke(config);
 
             AWSConfigs.LoggingConfig.LogTo = LoggingOptions.SystemDiagnostics;
-            AWSConfigs.AddTraceListener("Amazon", new AwsEvent(config.SuppressMessages.Prefixes));
+            AWSConfigs.AddTraceListener("Amazon", new AwsEvent(config.NoiseFilters.Prefixes));
 
             switch (config.LogResponses.ResponseLoggingOption)
             {
@@ -35,11 +35,11 @@ namespace Spiffy.Monitoring.Aws
 
         internal class AwsEvent : TraceListener
         {
-            readonly IReadOnlyList<string> _suppressedPrefixes;
+            readonly IReadOnlyList<string> _noisePrefixes;
 
-            public AwsEvent(IReadOnlyList<string> suppressedPrefixes)
+            public AwsEvent(IReadOnlyList<string> noisePrefixes)
             {
-                _suppressedPrefixes = suppressedPrefixes;
+                _noisePrefixes = noisePrefixes;
             }
 
             // TraceData is a System.Diagnostics.TraceListener member, so what's overridden here
@@ -83,7 +83,7 @@ namespace Spiffy.Monitoring.Aws
                 {
                     return;
                 }
-                if (!IsActionable(eventType) && IsSuppressed(message))
+                if (IsNoise(eventType, message))
                 {
                     return;
                 }
@@ -118,22 +118,19 @@ namespace Spiffy.Monitoring.Aws
                 }
             }
 
-            static bool IsActionable(TraceEventType eventType)
+            // Severity decides first: only what the SDK reports below Warning is eligible for
+            // prefix matching.
+            bool IsNoise(TraceEventType eventType, string message)
             {
                 switch (eventType)
                 {
                     case TraceEventType.Critical:
                     case TraceEventType.Error:
                     case TraceEventType.Warning:
-                        return true;
-                    default:
                         return false;
+                    default:
+                        return _noisePrefixes.Any(prefix => message.StartsWith(prefix, StringComparison.Ordinal));
                 }
-            }
-
-            bool IsSuppressed(string message)
-            {
-                return _suppressedPrefixes.Any(prefix => message.StartsWith(prefix, StringComparison.Ordinal));
             }
 
             public override string Name { get; set; } = nameof(AwsEvent);

--- a/src/Spiffy.Monitoring.Aws/AwsProvider.cs
+++ b/src/Spiffy.Monitoring.Aws/AwsProvider.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Amazon;
 using Spiffy.Monitoring.Config;
 
@@ -9,11 +11,11 @@ namespace Spiffy.Monitoring.Aws
     {
         public static InitializationApi.ProvidersApi Aws(this InitializationApi.ProvidersApi providers, Action<AwsConfigurationApi> configure = null)
         {
-            AWSConfigs.LoggingConfig.LogTo = LoggingOptions.SystemDiagnostics;
-            AWSConfigs.AddTraceListener("Amazon", new AwsEvent());
-
             var config = new AwsConfigurationApi();
             configure?.Invoke(config);
+
+            AWSConfigs.LoggingConfig.LogTo = LoggingOptions.SystemDiagnostics;
+            AWSConfigs.AddTraceListener("Amazon", new AwsEvent(config.SuppressMessages.Prefixes));
 
             switch (config.LogResponses.ResponseLoggingOption)
             {
@@ -31,57 +33,107 @@ namespace Spiffy.Monitoring.Aws
             return providers;
         }
 
-        class AwsEvent : TraceListener
+        internal class AwsEvent : TraceListener
         {
+            readonly IReadOnlyList<string> _suppressedPrefixes;
+
+            public AwsEvent(IReadOnlyList<string> suppressedPrefixes)
+            {
+                _suppressedPrefixes = suppressedPrefixes;
+            }
+
+            // TraceData is a System.Diagnostics.TraceListener member, so what's overridden here
+            // is BCL surface -- nothing about it is tied to an SDK version, and one
+            // implementation serves both majors.  Both report exclusively through
+            // TraceSource.TraceData (v3 via InternalSystemDiagnosticsLogger, v4 via
+            // DiagnosticAdaptorLogger), which is where the severity is available;
+            // Write/WriteLine only ever see the flattened string.  Every v4 message lands on
+            // this overload, as do v3's InfoFormat/DebugFormat.
+            public override void TraceData(TraceEventCache eventCache, string source, TraceEventType eventType, int id, object data)
+            {
+                Handle(eventType, data?.ToString(), null);
+            }
+
+            // Only v3 reaches this overload, from Error/Debug, which pass the message and the
+            // exception separately.  v4 accepts an exception and discards it before this point.
+            public override void TraceData(TraceEventCache eventCache, string source, TraceEventType eventType, int id, params object[] data)
+            {
+                if (data == null || data.Length == 0)
+                {
+                    return;
+                }
+                Handle(eventType, data[0]?.ToString(), data.Length > 1 ? data[1] as Exception : null);
+            }
+
             public override void Write(string message)
             {
-                // these messages tend to be useless, e.g.
-                // Message="Amazon Information: 0 : "
+                // headers, e.g. Message="Amazon Information: 0 : "
             }
 
+            // Nothing in the SDK reaches the listener this way today, but a caller that
+            // bypasses TraceData carries no severity, so treat it as informational.
             public override void WriteLine(string message)
             {
-                Handle(message);
+                Handle(TraceEventType.Information, message, null);
             }
 
-            void Handle(string message)
+            void Handle(TraceEventType eventType, string message, Exception exception)
             {
                 if (string.IsNullOrWhiteSpace(message))
                 {
                     return;
                 }
-                if (!IsSdkSpam(message))
+                if (!IsActionable(eventType) && IsSuppressed(message))
                 {
-                    using (var context = new EventContext("AwsSdk", "Event"))
-                    {
-                        context["Message"] = message;
+                    return;
+                }
 
-                        // some example exception messages:
-                        // An exception of type HttpErrorResponseException was handled in ErrorHandler...
-                        // UnsupportedLanguagePairException making request TranslateTextRequest...
-                        // An exception of type TimeoutException was handled in ErrorHandler...
-                        if (message.IndexOf("exception", Math.Min(100, message.Length), StringComparison.OrdinalIgnoreCase) != -1)
+                using (var context = new EventContext("AwsSdk", "Event"))
+                {
+                    context["Message"] = message;
+
+                    if (eventType == TraceEventType.Error || eventType == TraceEventType.Critical)
+                    {
+                        if (exception == null)
                         {
                             context.SetToError();
+                        }
+                        else
+                        {
+                            // also sets the level to error
+                            context.IncludeException(exception);
+                        }
+                    }
+                    else
+                    {
+                        if (eventType == TraceEventType.Warning)
+                        {
+                            context.SetToWarning();
+                        }
+                        if (exception != null)
+                        {
+                            context.IncludeInformationalException(exception, "Exception");
                         }
                     }
                 }
             }
 
-            static bool IsSdkSpam(string message)
+            static bool IsActionable(TraceEventType eventType)
             {
-                // this message happens often and for all configurations (legacy/standard/etc)
-                if (message.StartsWith("Resolved DefaultConfigurationMode for RegionEndpoint"))
+                switch (eventType)
                 {
-                    return true;
+                    case TraceEventType.Critical:
+                    case TraceEventType.Error:
+                    case TraceEventType.Warning:
+                        return true;
+                    default:
+                        return false;
                 }
-                // this message happens as part of routine DynamoDB usage
-                if (message.StartsWith("Description for table") && message.EndsWith("loaded from SDK Cache"))
-                {
-                    return true;
-                }
+            }
 
-                return false;
+            bool IsSuppressed(string message)
+            {
+                return _suppressedPrefixes.Any(prefix => message.StartsWith(prefix, StringComparison.Ordinal));
             }
 
             public override string Name { get; set; } = nameof(AwsEvent);

--- a/src/Spiffy.Monitoring.Aws/Properties/AssemblyInfo.cs
+++ b/src/Spiffy.Monitoring.Aws/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UnitTests")]

--- a/src/Spiffy.Monitoring.Aws/Spiffy.Monitoring.Aws.csproj
+++ b/src/Spiffy.Monitoring.Aws/Spiffy.Monitoring.Aws.csproj
@@ -12,7 +12,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-        <Version>2.0.3</Version>
+        <Version>2.1.0</Version>
         <RootNamespace>Spiffy.Monitoring.Aws</RootNamespace>
     </PropertyGroup>
 

--- a/tests/TestConsoleApp/Program.cs
+++ b/tests/TestConsoleApp/Program.cs
@@ -79,11 +79,20 @@ namespace TestConsoleApp
                                 .OverrideValues(OverrideValues)
                             .ToCounter("my_app_my_counter", "Counter Help String");
                         break;
+                    // pass "unfiltered" to see what the default suppression is removing
                     case "aws":
+                        var unfiltered = args.Length > 1 && args[1].Trim().ToLower() == "unfiltered";
                         Configuration.Initialize(spiffy =>
                             spiffy.Providers
                                 .Console()
-                                .Aws(c => c.LogResponses.Always()));
+                                .Aws(c =>
+                                {
+                                    c.LogResponses.Always();
+                                    if (unfiltered)
+                                    {
+                                        c.SuppressMessages.None();
+                                    }
+                                }));
                         var id = new AmazonSecurityTokenServiceClient()
                             .GetCallerIdentityAsync(new GetCallerIdentityRequest()).Result;
                         break;

--- a/tests/TestConsoleApp/Program.cs
+++ b/tests/TestConsoleApp/Program.cs
@@ -90,7 +90,7 @@ namespace TestConsoleApp
                                     c.LogResponses.Always();
                                     if (unfiltered)
                                     {
-                                        c.SuppressMessages.None();
+                                        c.NoiseFilters.Clear();
                                     }
                                 }));
                         var id = new AmazonSecurityTokenServiceClient()

--- a/tests/TestConsoleApp/TestConsoleApp.csproj
+++ b/tests/TestConsoleApp/TestConsoleApp.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <DebugType>portable</DebugType>
         <OutputTypeEx>exe</OutputTypeEx>
     </PropertyGroup>

--- a/tests/TestWebApp/TestWebApp.csproj
+++ b/tests/TestWebApp/TestWebApp.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/tests/UnitTests/AwsListenerTests.cs
+++ b/tests/UnitTests/AwsListenerTests.cs
@@ -1,0 +1,329 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using AwesomeAssertions;
+using Kekiri.Xunit;
+using Spiffy.Monitoring;
+using Spiffy.Monitoring.Aws;
+using Xunit;
+
+namespace UnitTests;
+
+// The listener builds its EventContext from the ambient Configuration, so these scenarios
+// have to take turns installing a capturing provider into Configuration.Default.
+[CollectionDefinition(AwsListener.Collection, DisableParallelization = true)]
+public class AwsListener
+{
+    public const string Collection = "AwsListener";
+}
+
+public class AwsListenerTestContext
+{
+    readonly List<LogEvent> _loggedEvents = new();
+    AwsProvider.AwsEvent _listener;
+
+    public void Initialize(Action<AwsConfigurationApi> configure = null)
+    {
+        _loggedEvents.Clear();
+        Configuration.Initialize(spiffy => spiffy.Providers.Add("test", _loggedEvents.Add));
+
+        var config = new AwsConfigurationApi();
+        configure?.Invoke(config);
+        _listener = new AwsProvider.AwsEvent(config.SuppressMessages.Prefixes);
+    }
+
+    // Mirrors how the SDK reports.  A lone message is what v4 always sends -- its
+    // DiagnosticAdaptorLogger accepts the exception and then drops it -- and what v3 sends
+    // for InfoFormat/DebugFormat.
+    public void Report(TraceEventType eventType, string message)
+    {
+        _listener.TraceData(null, "Amazon", eventType, 0, message);
+    }
+
+    // Message plus exception is v3 only, from Error/Debug.
+    public void Report(TraceEventType eventType, string message, Exception exception)
+    {
+        _listener.TraceData(null, "Amazon", eventType, 0, message, exception);
+    }
+
+    public IReadOnlyList<LogEvent> LoggedEvents => _loggedEvents;
+    public LogEvent SingleLogEvent => _loggedEvents.Single();
+}
+
+[Collection(AwsListener.Collection)]
+public class AwsListenerSeverity : Scenarios<AwsListenerTestContext>
+{
+    const string ErrorMessage = "An exception of type HttpErrorResponseException was handled in ErrorHandler.";
+
+    [Scenario]
+    public void Errors_are_reported_as_errors()
+    {
+        Given(A_listener);
+        When(The_sdk_reports, TraceEventType.Error, ErrorMessage);
+        Then(One_event_is_logged, ErrorMessage)
+            .And(The_level_is, Level.Error);
+    }
+
+    [Scenario]
+    public void Critical_is_reported_as_error()
+    {
+        Given(A_listener);
+        When(The_sdk_reports, TraceEventType.Critical, "Something dire");
+        Then(One_event_is_logged, "Something dire")
+            .And(The_level_is, Level.Error);
+    }
+
+    [Scenario]
+    public void Warnings_are_reported_as_warnings()
+    {
+        Given(A_listener);
+        When(The_sdk_reports, TraceEventType.Warning, "Something suspect");
+        Then(One_event_is_logged, "Something suspect")
+            .And(The_level_is, Level.Warning);
+    }
+
+    [Scenario]
+    public void Information_is_reported_as_info()
+    {
+        Given(A_listener);
+        When(The_sdk_reports, TraceEventType.Information, "Credentials found using environment variables.");
+        Then(One_event_is_logged, "Credentials found using environment variables.")
+            .And(The_level_is, Level.Info);
+    }
+
+    // The message the old substring heuristic was meant to catch is 76 characters long, so
+    // its `IndexOf("exception", Math.Min(100, length))` start offset landed past the end.
+    [Scenario]
+    public void Severity_classifies_errors_the_substring_heuristic_missed()
+    {
+        Given(A_listener);
+        When(The_sdk_reports, TraceEventType.Error, ErrorMessage);
+        Then(The_level_is, Level.Error)
+            .And(The_message_does_not_announce_its_own_severity);
+    }
+
+    void The_message_does_not_announce_its_own_severity()
+    {
+        ErrorMessage.IndexOf("exception", Math.Min(100, ErrorMessage.Length), StringComparison.OrdinalIgnoreCase)
+            .Should().Be(-1, because: "otherwise this test isn't covering what the heuristic missed");
+    }
+
+    void A_listener()
+    {
+        Context.Initialize();
+    }
+
+    void The_sdk_reports(TraceEventType eventType, string message)
+    {
+        Context.Report(eventType, message);
+    }
+
+    void One_event_is_logged(string expectedMessage)
+    {
+        Context.SingleLogEvent.Message.Should().Contain(expectedMessage);
+    }
+
+    void The_level_is(Level expectedLevel)
+    {
+        Context.SingleLogEvent.Level.Should().Be(expectedLevel);
+    }
+}
+
+[Collection(AwsListener.Collection)]
+public class AwsListenerExceptions : Scenarios<AwsListenerTestContext>
+{
+    // Only reachable on SDK v3, which is why the package floor still matters: v4 drops the
+    // exception inside the SDK, so a v4 application gets the message text and no Exception_* fields.
+    [Scenario]
+    public void Errors_carry_exception_detail()
+    {
+        Given(A_listener);
+        When(The_sdk_reports_an_exception_at, TraceEventType.Error);
+        Then(The_event_has_exception_fields)
+            .And(The_level_is, Level.Error);
+    }
+
+    // v3 reports Debug(exception, ...) at Verbose; an exception arriving at that
+    // severity shouldn't escalate the event to an error.
+    [Scenario]
+    public void Verbose_exceptions_do_not_escalate()
+    {
+        Given(A_listener);
+        When(The_sdk_reports_an_exception_at, TraceEventType.Verbose);
+        Then(The_event_has_exception_fields)
+            .And(The_level_is, Level.Info);
+    }
+
+    void A_listener()
+    {
+        Context.Initialize();
+    }
+
+    void The_sdk_reports_an_exception_at(TraceEventType eventType)
+    {
+        Context.Report(eventType, "Something went sideways", new TimeoutException("boom"));
+    }
+
+    void The_event_has_exception_fields()
+    {
+        var properties = Context.SingleLogEvent.Properties;
+        properties.Should().ContainKey("Exception_Type");
+        properties["Exception_Type"].Should().Be(nameof(TimeoutException));
+        properties.Should().ContainKey("Exception_Message");
+        properties["Exception_Message"].Should().Contain("boom");
+    }
+
+    void The_level_is(Level expectedLevel)
+    {
+        Context.SingleLogEvent.Level.Should().Be(expectedLevel);
+    }
+}
+
+[Collection(AwsListener.Collection)]
+public class AwsListenerSuppression : Scenarios<AwsListenerTestContext>
+{
+    // The messages here are taken verbatim from a production log query, so a change to the
+    // prefixes has to keep clearing the traffic that motivated them.
+    [ScenarioOutline]
+    [Example("User-Agent Header: aws-sdk-dotnet-coreclr/4.0.9.6 ua/2.1 os/linux#6.1.175.219 md/ARCH#Arm64 api/DynamoDB#4.0.9.6")]
+    [Example("Resizing buffer from 4096 to 8192")]
+    [Example("Resolved DefaultConfigurationMode for RegionEndpoint [us-east-1] to [Standard].")]
+    [Example("Description for table [my-table] loaded from SDK Cache")]
+    [Example("The environment variable AWS_MAX_ATTEMPTS was not set with a value.")]
+    [Example("Retry check: IsStaleConnectionError=False, CanRetry=True, staleConnectionRetries=0, maxStaleConnectionRetries=10, IsRequestStreamRewindable=True")]
+    [Example("Single encoded /{Key+} with endpoint https://example.s3.us-west-2.amazonaws.com/ for canonicalization: /public/getty/workbench-pages/index.xml.gz")]
+    [Example("Double encoded /usageplans with endpoint https://apigateway.us-west-2.amazonaws.com/ for canonicalization: /usageplans")]
+    public void Noise_is_suppressed_by_default(string message)
+    {
+        Given(A_listener);
+        When(The_sdk_reports_at_information, message);
+        Then(Nothing_is_logged);
+    }
+
+    [Scenario]
+    public void Unrecognized_information_still_flows()
+    {
+        Given(A_listener);
+        When(The_sdk_reports_at_information, "Region found using environment variable.");
+        Then(One_event_is_logged);
+    }
+
+    // Failures and throttling arrive at Information too -- RetryHandler uses InfoFormat -- so
+    // they survive only because the filter denies rather than allows.  Note the contrast with
+    // the suppressed "Retry check: " bookkeeping: a retry *notice* names what went wrong.
+    [ScenarioOutline]
+    [Example("ProvisionedThroughputExceededException making request BatchGetItemRequest to https://dynamodb.us-west-2.amazonaws.com/. Attempting retry 1 of 10.")]
+    [Example("AmazonS3Exception making request GetObjectMetadataRequest to https://example.s3.us-west-2.amazonaws.com/. Attempt 1.")]
+    [Example("UnsupportedLanguagePairException making request TranslateTextRequest to https://translate.us-east-1.amazonaws.com/. Attempting retry 1 of 4.")]
+    public void Failure_notices_at_information_still_flow(string message)
+    {
+        Given(A_listener);
+        When(The_sdk_reports_at_information, message);
+        Then(One_event_is_logged);
+    }
+
+    [Scenario]
+    public void Suppression_never_applies_to_errors()
+    {
+        Given(A_listener);
+        When(The_sdk_reports_an_error, "User-Agent Header: something went wrong while building it");
+        Then(One_event_is_logged);
+    }
+
+    static readonly Action<AwsConfigurationApi> SuppressNothing = c => c.SuppressMessages.None();
+    static readonly Action<AwsConfigurationApi> AlsoSuppressRegion = c => c.SuppressMessages.Add("Region found using");
+    static readonly Action<AwsConfigurationApi> OnlySuppressRegion = c => c.SuppressMessages.Only("Region found using");
+
+    static readonly Action<AwsConfigurationApi> AlsoSuppressRegionAndCredentials = c =>
+    {
+        c.SuppressMessages.Add("Region found using");
+        c.SuppressMessages.Add("Credentials found using");
+    };
+
+    [Scenario]
+    public void None_disables_suppression()
+    {
+        Given(A_listener_configured_with, SuppressNothing);
+        When(The_sdk_reports_at_information, "User-Agent Header: aws-sdk-dotnet-coreclr/4.0.2.11");
+        Then(One_event_is_logged);
+    }
+
+    [Scenario]
+    public void Add_extends_the_defaults()
+    {
+        Given(A_listener_configured_with, AlsoSuppressRegion);
+        When(The_sdk_reports_at_information, "Region found using environment variable.");
+        Then(Nothing_is_logged);
+    }
+
+    [Scenario]
+    public void Add_keeps_the_defaults()
+    {
+        Given(A_listener_configured_with, AlsoSuppressRegion);
+        When(The_sdk_reports_at_information, "User-Agent Header: aws-sdk-dotnet-coreclr/4.0.2.11");
+        Then(Nothing_is_logged);
+    }
+
+    [Scenario]
+    public void Add_accumulates_across_calls()
+    {
+        Given(A_listener_configured_with, AlsoSuppressRegionAndCredentials);
+        When(The_sdk_reports_at_information, "Region found using environment variable.");
+        Then(Nothing_is_logged);
+    }
+
+    [Scenario]
+    public void Only_discards_the_defaults()
+    {
+        Given(A_listener_configured_with, OnlySuppressRegion);
+        When(The_sdk_reports_at_information, "User-Agent Header: aws-sdk-dotnet-coreclr/4.0.2.11");
+        Then(One_event_is_logged);
+    }
+
+    [Scenario]
+    public void Only_suppresses_what_it_names()
+    {
+        Given(A_listener_configured_with, OnlySuppressRegion);
+        When(The_sdk_reports_at_information, "Region found using environment variable.");
+        Then(Nothing_is_logged);
+    }
+
+    [Scenario]
+    public void Blank_messages_are_dropped()
+    {
+        Given(A_listener);
+        When(The_sdk_reports_at_information, "   ");
+        Then(Nothing_is_logged);
+    }
+
+    void A_listener()
+    {
+        Context.Initialize();
+    }
+
+    void A_listener_configured_with(Action<AwsConfigurationApi> configure)
+    {
+        Context.Initialize(configure);
+    }
+
+    void The_sdk_reports_at_information(string message)
+    {
+        Context.Report(TraceEventType.Information, message);
+    }
+
+    void The_sdk_reports_an_error(string message)
+    {
+        Context.Report(TraceEventType.Error, message);
+    }
+
+    void Nothing_is_logged()
+    {
+        Context.LoggedEvents.Should().BeEmpty();
+    }
+
+    void One_event_is_logged()
+    {
+        Context.LoggedEvents.Should().HaveCount(1);
+    }
+}

--- a/tests/UnitTests/AwsListenerTests.cs
+++ b/tests/UnitTests/AwsListenerTests.cs
@@ -10,19 +10,14 @@ using Xunit;
 
 namespace UnitTests;
 
-// The listener builds its EventContext from the ambient Configuration, so these scenarios
-// have to take turns installing a capturing provider into Configuration.Default.
-[CollectionDefinition(AwsListener.Collection, DisableParallelization = true)]
-public class AwsListener
-{
-    public const string Collection = "AwsListener";
-}
-
 public class AwsListenerTestContext
 {
     readonly List<LogEvent> _loggedEvents = new();
     AwsProvider.AwsEvent _listener;
 
+    // The listener builds its EventContext from the ambient Configuration, so capturing what it
+    // logs means installing a provider into the global Configuration.Default.  Properties/
+    // AssemblyInfo.cs turns off test parallelization for that reason.
     public void Initialize(Action<AwsConfigurationApi> configure = null)
     {
         _loggedEvents.Clear();
@@ -30,7 +25,7 @@ public class AwsListenerTestContext
 
         var config = new AwsConfigurationApi();
         configure?.Invoke(config);
-        _listener = new AwsProvider.AwsEvent(config.SuppressMessages.Prefixes);
+        _listener = new AwsProvider.AwsEvent(config.NoiseFilters.Prefixes);
     }
 
     // Mirrors how the SDK reports.  A lone message is what v4 always sends -- its
@@ -51,7 +46,6 @@ public class AwsListenerTestContext
     public LogEvent SingleLogEvent => _loggedEvents.Single();
 }
 
-[Collection(AwsListener.Collection)]
 public class AwsListenerSeverity : Scenarios<AwsListenerTestContext>
 {
     const string ErrorMessage = "An exception of type HttpErrorResponseException was handled in ErrorHandler.";
@@ -130,7 +124,6 @@ public class AwsListenerSeverity : Scenarios<AwsListenerTestContext>
     }
 }
 
-[Collection(AwsListener.Collection)]
 public class AwsListenerExceptions : Scenarios<AwsListenerTestContext>
 {
     // Only reachable on SDK v3, which is why the package floor still matters: v4 drops the
@@ -180,8 +173,7 @@ public class AwsListenerExceptions : Scenarios<AwsListenerTestContext>
     }
 }
 
-[Collection(AwsListener.Collection)]
-public class AwsListenerSuppression : Scenarios<AwsListenerTestContext>
+public class AwsListenerNoiseFilters : Scenarios<AwsListenerTestContext>
 {
     // The messages here are taken verbatim from a production log query, so a change to the
     // prefixes has to keep clearing the traffic that motivated them.
@@ -194,7 +186,7 @@ public class AwsListenerSuppression : Scenarios<AwsListenerTestContext>
     [Example("Retry check: IsStaleConnectionError=False, CanRetry=True, staleConnectionRetries=0, maxStaleConnectionRetries=10, IsRequestStreamRewindable=True")]
     [Example("Single encoded /{Key+} with endpoint https://example.s3.us-west-2.amazonaws.com/ for canonicalization: /public/getty/workbench-pages/index.xml.gz")]
     [Example("Double encoded /usageplans with endpoint https://apigateway.us-west-2.amazonaws.com/ for canonicalization: /usageplans")]
-    public void Noise_is_suppressed_by_default(string message)
+    public void Noise_is_filtered_by_default(string message)
     {
         Given(A_listener);
         When(The_sdk_reports_at_information, message);
@@ -224,35 +216,73 @@ public class AwsListenerSuppression : Scenarios<AwsListenerTestContext>
     }
 
     [Scenario]
-    public void Suppression_never_applies_to_errors()
+    public void Filtering_never_applies_to_errors()
     {
         Given(A_listener);
         When(The_sdk_reports_an_error, "User-Agent Header: something went wrong while building it");
         Then(One_event_is_logged);
     }
 
-    static readonly Action<AwsConfigurationApi> SuppressNothing = c => c.SuppressMessages.None();
-    static readonly Action<AwsConfigurationApi> AlsoSuppressRegion = c => c.SuppressMessages.Add("Region found using");
-    static readonly Action<AwsConfigurationApi> OnlySuppressRegion = c => c.SuppressMessages.Only("Region found using");
+    const string UserAgentMessage = "User-Agent Header: aws-sdk-dotnet-coreclr/4.0.2.11";
 
-    static readonly Action<AwsConfigurationApi> AlsoSuppressRegionAndCredentials = c =>
+    static readonly Action<AwsConfigurationApi> FilterNothing = c => c.NoiseFilters.Clear();
+    static readonly Action<AwsConfigurationApi> KeepUserAgent = c => c.NoiseFilters.Remove(SdkNoise.UserAgentHeader);
+    static readonly Action<AwsConfigurationApi> AlsoFilterRegion = c => c.NoiseFilters.Add("Region found using");
+
+    static readonly Action<AwsConfigurationApi> OnlyFilterRegion = c =>
     {
-        c.SuppressMessages.Add("Region found using");
-        c.SuppressMessages.Add("Credentials found using");
+        c.NoiseFilters.Clear();
+        c.NoiseFilters.Add("Region found using");
+    };
+
+    static readonly Action<AwsConfigurationApi> AlsoFilterRegionAndCredentials = c =>
+    {
+        c.NoiseFilters.Add("Region found using");
+        c.NoiseFilters.Add("Credentials found using");
     };
 
     [Scenario]
-    public void None_disables_suppression()
+    public void Clear_disables_filtering()
     {
-        Given(A_listener_configured_with, SuppressNothing);
-        When(The_sdk_reports_at_information, "User-Agent Header: aws-sdk-dotnet-coreclr/4.0.2.11");
+        Given(A_listener_configured_with, FilterNothing);
+        When(The_sdk_reports_at_information, UserAgentMessage);
         Then(One_event_is_logged);
     }
 
     [Scenario]
+    public void Remove_stops_filtering_one_kind()
+    {
+        Given(A_listener_configured_with, KeepUserAgent);
+        When(The_sdk_reports_at_information, UserAgentMessage);
+        Then(One_event_is_logged);
+    }
+
+    [Scenario]
+    public void Remove_leaves_the_other_kinds_filtered()
+    {
+        Given(A_listener_configured_with, KeepUserAgent);
+        When(The_sdk_reports_at_information, "Retry check: IsStaleConnectionError=False, CanRetry=True");
+        Then(Nothing_is_logged);
+    }
+
+    // RequestCanonicalization covers two prefixes, so removing it has to clear both.
+    [ScenarioOutline]
+    [Example("Single encoded /{Key+} with endpoint https://example.s3.us-west-2.amazonaws.com/ for canonicalization: /a.gz")]
+    [Example("Double encoded /usageplans with endpoint https://apigateway.us-west-2.amazonaws.com/ for canonicalization: /usageplans")]
+    public void Removing_a_kind_covers_all_its_prefixes(string message)
+    {
+        Given(A_listener_configured_with, KeepCanonicalization);
+        When(The_sdk_reports_at_information, message);
+        Then(One_event_is_logged);
+    }
+
+    static readonly Action<AwsConfigurationApi> KeepCanonicalization =
+        c => c.NoiseFilters.Remove(SdkNoise.RequestCanonicalization);
+
+    [Scenario]
     public void Add_extends_the_defaults()
     {
-        Given(A_listener_configured_with, AlsoSuppressRegion);
+        Given(A_listener_configured_with, AlsoFilterRegion);
         When(The_sdk_reports_at_information, "Region found using environment variable.");
         Then(Nothing_is_logged);
     }
@@ -260,31 +290,31 @@ public class AwsListenerSuppression : Scenarios<AwsListenerTestContext>
     [Scenario]
     public void Add_keeps_the_defaults()
     {
-        Given(A_listener_configured_with, AlsoSuppressRegion);
-        When(The_sdk_reports_at_information, "User-Agent Header: aws-sdk-dotnet-coreclr/4.0.2.11");
+        Given(A_listener_configured_with, AlsoFilterRegion);
+        When(The_sdk_reports_at_information, UserAgentMessage);
         Then(Nothing_is_logged);
     }
 
     [Scenario]
     public void Add_accumulates_across_calls()
     {
-        Given(A_listener_configured_with, AlsoSuppressRegionAndCredentials);
+        Given(A_listener_configured_with, AlsoFilterRegionAndCredentials);
         When(The_sdk_reports_at_information, "Region found using environment variable.");
         Then(Nothing_is_logged);
     }
 
     [Scenario]
-    public void Only_discards_the_defaults()
+    public void Clear_then_Add_discards_the_defaults()
     {
-        Given(A_listener_configured_with, OnlySuppressRegion);
-        When(The_sdk_reports_at_information, "User-Agent Header: aws-sdk-dotnet-coreclr/4.0.2.11");
+        Given(A_listener_configured_with, OnlyFilterRegion);
+        When(The_sdk_reports_at_information, UserAgentMessage);
         Then(One_event_is_logged);
     }
 
     [Scenario]
-    public void Only_suppresses_what_it_names()
+    public void Clear_then_Add_filters_what_it_names()
     {
-        Given(A_listener_configured_with, OnlySuppressRegion);
+        Given(A_listener_configured_with, OnlyFilterRegion);
         When(The_sdk_reports_at_information, "Region found using environment variable.");
         Then(Nothing_is_logged);
     }
@@ -295,6 +325,36 @@ public class AwsListenerSuppression : Scenarios<AwsListenerTestContext>
         Given(A_listener);
         When(The_sdk_reports_at_information, "   ");
         Then(Nothing_is_logged);
+    }
+
+    // A member added to SdkNoise without a prefix mapping would filter nothing, silently.
+    [Scenario]
+    public void Every_kind_maps_to_at_least_one_prefix()
+    {
+        When(Filtering_each_kind_on_its_own);
+        Then(No_kind_is_left_unmapped);
+    }
+
+    readonly List<SdkNoise> _unmappedKinds = new();
+
+    void Filtering_each_kind_on_its_own()
+    {
+        foreach (SdkNoise kind in Enum.GetValues(typeof(SdkNoise)))
+        {
+            var config = new AwsConfigurationApi();
+            config.NoiseFilters.Clear();
+            config.NoiseFilters.Add(kind);
+
+            if (!config.NoiseFilters.Prefixes.Any())
+            {
+                _unmappedKinds.Add(kind);
+            }
+        }
+    }
+
+    void No_kind_is_left_unmapped()
+    {
+        _unmappedKinds.Should().BeEmpty(because: "a kind with no prefix mapping filters nothing");
     }
 
     void A_listener()

--- a/tests/UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+// AwsListenerTests installs a capturing provider into the process-global Configuration.Default,
+// because the listener under test builds its EventContext from the ambient Configuration.  Any
+// test that disposes an EventContext constructed without an explicit Configuration would publish
+// into whichever list is installed at that moment, so no other test may run alongside those.
+// Scoping this to a collection wouldn't be enough: xunit parallelizes across collections.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <DebugType>portable</DebugType>
         <ApplicationIcon />
         <OutputTypeEx>library</OutputTypeEx>

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -14,6 +14,7 @@
     
     <ItemGroup>
         <ProjectReference Include="..\..\src\Spiffy.Monitoring\Spiffy.Monitoring.csproj" />
+        <ProjectReference Include="..\..\src\Spiffy.Monitoring.Aws\Spiffy.Monitoring.Aws.csproj" />
         <PackageReference Include="AwesomeAssertions" Version="9.1.*" />
         <PackageReference Include="Kekiri" Version="5.1.*" />
         <PackageReference Include="Kekiri.Xunit" Version="1.2.*" />


### PR DESCRIPTION
## Context

`Spiffy.Monitoring.Aws` installs a `TraceListener` into the AWS SDK's diagnostics pipeline, so anything the SDK reports shows up in the host application's structured logs as `Component=AwsSdk Operation=Event`. Everything the SDK emitted became a log event, minus a two-entry deny-list. This makes that filtering the library's job instead of every consumer's, and classifies each event from the severity the SDK actually reported rather than guessing from the message text. Closes #52.

The SDK reports a great deal at informational severity, and some of it repeats on every call while carrying nothing actionable. A production log query over one window returned 2.9M `AwsSdk` events, 94% of which were a single message restating the SDK's own user-agent string; a separate query put the request-signing canonicalization lines at 4.3M/day on their own. Consumers were each solving this by hand — a `BeforeLogging` callback hardcoding the same prefixes, or `RemoveTraceListener`, which runs too late to help because clients have already captured the listener.

## Review guide

**Critical path**
- [`src/Spiffy.Monitoring.Aws/AwsProvider.cs:123`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-8689f6ccc52c6311471134cc23ffcec0dde06421e26aeb17c743a051caeab8a8R123) — the whole filter decision: severity short-circuits, prefixes decide the rest, `Warning` and above are never filtered
- [`src/Spiffy.Monitoring.Aws/AwsProvider.cs:52`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-8689f6ccc52c6311471134cc23ffcec0dde06421e26aeb17c743a051caeab8a8R52) — the severity is only available on `TraceData`; `Write`/`WriteLine` see a flattened string, which is why the old code had to guess

**Public surface**
- [`src/Spiffy.Monitoring.Aws/AwsConfigurationApi.cs:32`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-b0e9da78dd245850e7df127971ffb2a403de9e7c974d937e8160b1c6d4cb95c7R32) — `SdkNoise` names the seven kinds, so nothing is configured by magic string
- [`src/Spiffy.Monitoring.Aws/AwsConfigurationApi.cs:60`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-b0e9da78dd245850e7df127971ffb2a403de9e7c974d937e8160b1c6d4cb95c7R60) — kind → prefixes, ordered so the result is deterministic; `RequestCanonicalization` covers two
- [`src/Spiffy.Monitoring.Aws/AwsConfigurationApi.cs:91`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-b0e9da78dd245850e7df127971ffb2a403de9e7c974d937e8160b1c6d4cb95c7R91) — `Add` / `Remove` / `Clear`, plus the string overload of `Add` as the escape hatch

**Tests**
- [`tests/UnitTests/AwsListenerTests.cs:189`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-7013e93c5a1d96564c2ad57c6a28fd3e0acdb11ca1ba1db4cb159b598ac97808R189) — the filtered cases use production message text verbatim, so a later prefix edit can't silently stop clearing this traffic
- [`tests/UnitTests/AwsListenerTests.cs:211`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-7013e93c5a1d96564c2ad57c6a28fd3e0acdb11ca1ba1db4cb159b598ac97808R211) — the counterpart: throttling and failure notices arrive at `Information` and must survive
- [`tests/UnitTests/AwsListenerTests.cs:332`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-7013e93c5a1d96564c2ad57c6a28fd3e0acdb11ca1ba1db4cb159b598ac97808R332) — guards the failure mode the enum introduces: a member added without a prefix mapping filters nothing, silently
- [`tests/UnitTests/Properties/AssemblyInfo.cs:8`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-6981d452ae2e02349840bad6a2abaa7cff9a23c354873e56d03e9647c27d9350R8) — the listener builds its `EventContext` from the ambient `Configuration`, so capturing what it logs means installing a provider into `Configuration.Default`. Scoping that to a collection isn't enough, since xunit parallelizes *across* collections

**Ancillary**
- [`docs/setup.md:41`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-4ca53116333428d7d34e6d2a9a64069655c8c37d5d36b856320ac1a0c4cb9b23R41) — the AWS provider had no docs section; this adds one
- [`docs/setup.md:59`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-4ca53116333428d7d34e6d2a9a64069655c8c37d5d36b856320ac1a0c4cb9b23R59) — SDK v3 hands the exception to the listener and v4 discards it, so `Exception_*` fields appear only on v3
- [`tests/TestConsoleApp/Program.cs:84`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-b176329509358425261c76523788ed986baf0b4cbe163833b6ee32e458bec70cR84) — `-- aws` uses the defaults, `-- aws unfiltered` clears them, for eyeballing the delta against a live SDK

**Mechanical** — skim only
- [`src/Spiffy.Monitoring.Aws/Spiffy.Monitoring.Aws.csproj:15`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-299813946dc47eb60c8916475e5dfad768d319216a4d142762105bc7c252c169R15) — 2.0.3 → 2.1.0
- [`tests/UnitTests/UnitTests.csproj:17`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-0793174b8bef67b957f999f3f6f55de9d8957de25d8525469925da819325f081R17) and [`Properties/AssemblyInfo.cs`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-4edc606d8994e0d1fabfd97afca979b97b47615c276a0714d8de0429dc8e5e6d) — test wiring, so `AwsEvent` is reachable from the suite
- [`.github/workflows/ci.yml:22`](https://github.com/chris-peterson/spiffy/pull/53/changes#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR22) — unrelated to the filtering, riding along: the three test/sample projects target `net10.0` so `dotnet test` runs on a machine with only a current SDK installed. `publish.yml` and `api-compatibility.yml` move to `10.0.x` as well, since each restores or builds the whole solution and an 8.0 SDK fails outright on a `net10.0` project. The five library projects keep their target frameworks — `netstandard2.0` on four, `net6.0` on Prometheus

## Approach & trade-offs

**Deny-list, not allow-list.** The SDK reports failures at informational severity as well as at `Error` — `RetryHandler` uses `InfoFormat` for `… Attempting retry N of M.` and `Logger.Error` for `… Attempt N.`. So an allow-list keyed on severity would have dropped the DynamoDB throttling notices, which is the signal most worth alerting on in the production sample. Filtering named noise keeps unrecognized messages flowing by default.

**Kinds, not prefix strings.** A consumer can't guess `"Resolved DefaultConfigurationMode for RegionEndpoint"`, and the worst-served case was keeping *one* thing the defaults filter — previously that meant re-listing the other six. `Remove(SdkNoise.UserAgentHeader)` does it directly, and one kind can front several prefixes. Raw strings remain available via `Add` for noise `SdkNoise` can't name.

**Prefix matching, not regex.** Every message in the sample is distinguishable by its leading literal, and a prefix can't backtrack on a multi-megabyte-per-day path. The cost is that a message needing a mid-string match has to be handled by the consumer. One filter widened as a result: `Description for table` matched only alongside a `loaded from SDK Cache` suffix before, and now covers a description the SDK loaded as well as one it served from cache. Both are routine DynamoDB chatter, so the kind is `TableDescription` rather than `TableDescriptionCache`.

**Severity replaces a text heuristic that had a real bug.** The old classifier called `IndexOf("exception", Math.Min(100, message.Length), …)`. The intent was to search the first 100 characters, but that parameter is a *start index*, so for any message shorter than 100 the search began at its own end and returned -1. The SDK's canonical error string is 76 characters, so it was logged at `Info`. (`3d75010` added the `Math.Min` clamp to stop the original `IndexOf(…, 100, …)` from throwing on short messages; the clamp fixed the throw, not the semantics.)

## Validation

- [x] **Classified against a production log query** — 2.9M `AwsSdk` events — observed: 95.7% filtered, with every error, `Received error response`, and `ProvisionedThroughputExceededException` throttling event retained
- [x] **Anchored prefix query re-run against production** — `Message="Single encoded *" OR Message="Double encoded *"` — observed: 4.3M events/day, confirming the canonicalization lines are the largest single class
- [x] **Exercised against a live SDK v4 client** — `TestConsoleApp -- aws` vs `-- aws unfiltered` — observed: 9 events vs 27, error classification intact

Two default kinds are **not** covered by the production evidence above: `BufferResizing` and `TableDescription` aren't reachable through the STS path the harness exercises, so they rest on reading the SDK source. `DefaultConfigurationMode` is carried over unchanged and I couldn't locate it in current SDK source at all — an unmatched prefix is inert, so it's left in place.
